### PR TITLE
Use the right kernel, setup symlinks for firmware, install hostapd

### DIFF
--- a/kickstart/POSM_Server.cfg
+++ b/kickstart/POSM_Server.cfg
@@ -65,7 +65,7 @@ d-i partman-partitioning/confirm_write_new_label boolean true
 
 ### Base system installation
 #d-i base-installer/kernel/image string linux-generic
-d-i base-installer/kernel/image string linux-virtual
+d-i base-installer/kernel/image string linux-image-3.19.0-42-generic
 
 ### Account setup
 d-i passwd/root-login boolean true
@@ -144,6 +144,7 @@ d-i preseed/late_command string \
 		-k http://ks/posm/kickstart \
 		-s "mysql_pw=posm" -s "mysql_size=small" \
 		base \
+		wifi \
 		nodejs \
 		ruby \
 		gis \

--- a/kickstart/scripts/wifi-deploy.sh
+++ b/kickstart/scripts/wifi-deploy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Should use Ubuntu linux-image-3.19.0-42-generic
+deploy_wifi_ubuntu() {
+	ln -s /lib/firmware/iwlwifi-7265D-12.ucode /lib/firmware/iwlwifi-3165-9.ucode
+	ln -s /lib/firmware/iwlwifi-7265-12.ucode /lib/firmware/iwlwifi-3165-12.ucode
+	apt-get install -y hostapd
+}
+
+deploy wifi


### PR DESCRIPTION
First pass at getting things setup for hostap. The NUC is very picky and must use exactly this kernel and setup symlinks for the iwlwifi firmware blobs.
