### PR TITLE
Add missing peer dependencies

### DIFF
--- a/kickstart/scripts/tessera-deploy.sh
+++ b/kickstart/scripts/tessera-deploy.sh
@@ -9,7 +9,7 @@ deploy_tessera_ubuntu() {
   npm install -g tessera
   local prefix=`npm prefix -g`
   (cd $prefix/lib/node_modules/tessera && npm install mapnik)
-  (cd $prefix/lib/node_modules/tessera && npm install mbtiles tilelive-mapnik tilelive-carto tilelive-tmstyle tilelive-tmsource tilelive-file tilelive-http tilelive-mapbox)
+  (cd $prefix/lib/node_modules/tessera && npm install mbtiles tilelive-mapnik tilelive-carto tilelive-tmstyle tilelive-tmsource tilelive-file tilelive-http tilelive-mapbox tilejson tilelive-vector)
 
   # configure
   expand etc/tessera.conf /etc/tessera.conf.json


### PR DESCRIPTION
`tilejson` and `tilelive-vector` are required by other modules. Since our version of Node ships with npm 3.x, we need to expliclty install peer dependencies.
