### PR TITLE
Use posm.local as the FQDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Ubuntu Server Install Details for NUC
    * `Enter` to active the console
    * Type `umount /media`
    * `Alt-F1` to return to installer, and try to detect again
- * Set the hostname to `posm.lan`
+ * Set the hostname to `posm`
  * Set the local user name to `posm`
  * Set the time zone to `UTC` (press `End` key to get to the bottom of the list)
  * (Optional) Use LVM partitioning using only 20GB of space (so you can allocate remainder for data later)

--- a/kickstart/etc/settings
+++ b/kickstart/etc/settings
@@ -10,7 +10,7 @@ posm_netif="wlan0"
 posm_ssid="posm"
 posm_wpa_passphrase="awesomeposm" # 8..63 characters
 posm_wifi_channel="1"
-posm_domain="lan"
+posm_domain="local"
 posm_hostname="posm.$posm_domain"
 
 # urls


### PR DESCRIPTION
This means that the same settings used to connect when connected to the AP will also work from mDNS-enabled clients on the same LAN.

@jflemer-ndp thoughts?
