### PR TITLE
OpenMapKit paths proxy_path correctly

### DIFF
--- a/kickstart/etc/nginx-posm.conf
+++ b/kickstart/etc/nginx-posm.conf
@@ -1,6 +1,6 @@
 server {
   listen 80;
-  server_name {{posm_hostname}};
+  server_name {{posm_hostname}} {{posm_ip}};
 
   proxy_buffering off;
   proxy_http_version 1.1;
@@ -39,10 +39,32 @@ server {
   location /fp-tasks/ {
     proxy_pass http://127.0.0.1:{{fp_tasks_port}}/;
   }
-  location /omk {
+
+  # OpenMapKit ODK Collect Routes (must be root namespace)
+  location /formList {
+    proxy_pass http://127.0.0.1:{{omk_server_port}};
+  }
+  location /submission {
     proxy_pass http://127.0.0.1:{{omk_server_port}};
   }
 
+  # OpenMapKit Routes
+  location /info {
+    proxy_pass http://127.0.0.1:{{omk_server_port}};
+  }
+  location /deployments {
+    proxy_pass http://127.0.0.1:{{omk_server_port}};
+  }
+  location /public {
+    proxy_pass http://127.0.0.1:{{omk_server_port}};
+  }
+  location /submissions {
+    proxy_pass http://127.0.0.1:{{omk_server_port}};
+  }
+  location /upload-form {
+    proxy_pass http://127.0.0.1:{{omk_server_port}};
+  }
+  
   # static files for Field Papers
   location /fp/_/ {
     alias /opt/fp/data/;


### PR DESCRIPTION
Because we don't want ODK Collect user to have to type anything beyond `posm.local` in phone settings, this puts OMK paths at root. I can take some of them and put them in an `/omk/` namespace, but for now, everything is fully functional, and I'd like have this merged in, at least for now.

Note: I wasn't able to test this on a real NUC due to time constraints, but in theory, you should be able to just put in `posm.local` or `posm.lan` in ODK Collect when using the real server. When using a VM with avahai-daemon, I have to put in the actual IP address. With this nginx integration, I don't have to put in any port or subpath.
