### PR TITLE
OS X-specific instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ USB Auto-Build Process
  5. (optional) Put any local settings in `posm-build/kickstart/etc/settings.local`
  6. Boot the USB stick and pick `Install POSM Server` from the menu
 
+ USB Auto-Build Process (OS X)
+ =============================
+ 1. Download http://posm.s3.amazonaws.com/ubuntu-14.04.3-server-amd64.img
+ 2. [Image it to a USB
+   drive](http://www.ubuntu.com/download/desktop/create-a-usb-stick-on-mac-osx)
+   (`sudo dd if=ubuntu-14.04.3-server-amd64.img of=/dev/<USB> bs=1m` or similar).
+ 3. Clone this project to the root drive of the USB stick
+ 4. Copy `posm-build/grub/grub.cfg` to `boot/grub/grub.cfg` (on the USB stick)
+ 5. (optional) Put any local settings in `posm-build/kickstart/etc/settings.local`
+ 6. Boot the USB stick and pick `Install POSM Server` from the menu
 
 Interim Manual Build Process
 ============================


### PR DESCRIPTION
The standard instructions (on OS X) image the ISO to a USB stick, which is bootable, but is not mountable on OS X.

http://posm.s3.amazonaws.com/ubuntu-14.04.3-server-amd64.img was created by producing a FAT32-formatted partition using Disk Utility (with GPT and an EFI partition, to ensure that it's readable by OS X), running `syslinux -s` on it (to make it bootable), resizing it with `parted` (because the default partition size matches the drive size), `dd`ing it into a file, and running `truncate` so that that resulting image matches the partition size, not the size of the USB drive.
