### PR TITLE
Generate OAuth keys for iD instances

### DIFF
--- a/kickstart/etc/osm-web.upstart
+++ b/kickstart/etc/osm-web.upstart
@@ -10,6 +10,7 @@ env RAILS_RELATIVE_URL_ROOT="/osm"
 env SECRET_KEY_BASE=38ab4c0de2a6335be2d2c6f6972470f0dc4f750f5c8f5895e53e8a5889fcccfeeda82a29d99ce9d0860e7f10c39bc88f6b17ed4bcc8218cef3e2fec020706129
 env RAILS_SERVE_STATIC_FILES=true
 env PORT={{osm_web_port}}
+env OSM_ID_KEY={{osm_id_key}}
 
 respawn
 #respawn limit 5 60

--- a/kickstart/etc/settings
+++ b/kickstart/etc/settings
@@ -32,9 +32,6 @@ cgimap_port=54321
 fp_secret_key_base=redacted
 fp_mapzen_search_key=redacted
 
-# OSM
-osm_id_key=redacted
-
 # databases
 mysql_pw=posm
 mysql_size=small
@@ -48,6 +45,10 @@ osm_carto_pg_owner="gis"
 osm_carto_pg_users="root fp omk"
 macrocosm_pg_owner="macrocosm"
 macrocosm_pg_pass="macrocosm"
+
+# POSM iD keys (will be set during osm initialization)
+posm_id_key="unset"
+posm_id_secret="unset"
 
 node_ver=5
 

--- a/kickstart/scripts/id-deploy.sh
+++ b/kickstart/scripts/id-deploy.sh
@@ -17,6 +17,10 @@ deploy_id_ubuntu() {
   # patch hostname
   sed -i -e "s/posm\.local/${posm_hostname}/g" "$dst/index.html"
 
+  # patch credentials
+  sed -i -e "s/5A043yRSEugj4DJ5TljuapfnrflWDte8jTOcWLlT/${posm_id_key}/g" "$dst/index.html"
+  sed -i -e "s/aB3jKq1TRsCOUrfOIZ6oQMEDmv2ptV76PA54NGLL/${posm_id_secret}/g" "$dst/index.html"
+
   # "build"
   su - id -c "make -C '$dst'"
 }


### PR DESCRIPTION
Fixes AmericanRedCross/posm#57

This means that bootstrapping `id` must occur after (and during the same run as) `osm`.
