### PR TITLE
OMK Refactor with /omk namespace for routes

### DIFF
--- a/kickstart/etc/nginx-posm.conf
+++ b/kickstart/etc/nginx-posm.conf
@@ -89,19 +89,7 @@ server {
   }
 
   # OpenMapKit Routes
-  location /info {
-    proxy_pass http://127.0.0.1:{{omk_server_port}};
-  }
-  location /deployments {
-    proxy_pass http://127.0.0.1:{{omk_server_port}};
-  }
-  location /public {
-    proxy_pass http://127.0.0.1:{{omk_server_port}};
-  }
-  location /submissions {
-    proxy_pass http://127.0.0.1:{{omk_server_port}};
-  }
-  location /upload-form {
+  location /omk {
     proxy_pass http://127.0.0.1:{{omk_server_port}};
   }
 

--- a/kickstart/scripts/omk-deploy.sh
+++ b/kickstart/scripts/omk-deploy.sh
@@ -28,14 +28,11 @@ deploy_omk_server() {
 
   # fetch pyxform submodule
   wget -q -O /root/sources/pyxform.tar.gz "https://github.com/spatialdev/pyxform/archive/e486b54d34d299d54049923e03ca5a6a1169af40.tar.gz"
-  tar -zxf /root/sources/pyxform.tar.gz -C "$dst/OpenMapKitServer/odk/pyxform" --strip=1
+  tar -zxf /root/sources/pyxform.tar.gz -C "$dst/OpenMapKitServer/api/odk/pyxform" --strip=1
 
   # fetch iD submodule
   wget -q -O /root/sources/omk-id.tar.gz "https://github.com/AmericanRedCross/iD/archive/omk.tar.gz"
-  tar -zxf /root/sources/omk-id.tar.gz -C "$dst/OpenMapKitServer/public/id" --strip=1
-
-  # use default settings
-  cp $dst/OpenMapKitServer/settings.js.example $dst/OpenMapKitServer/settings.js
+  tar -zxf /root/sources/omk-id.tar.gz -C "$dst/OpenMapKitServer/pages/id" --strip=1
 
   # user / group omk should own this
   chown -R omk:omk "$dst/OpenMapKitServer"


### PR DESCRIPTION
OMK Refactor has been pushed to master, these tweaks are made to work with posm-build.

All routes have a `/omk` prefix except for the ODK Collect OpenRosa routes that need to be root.

Closes https://github.com/AmericanRedCross/posm/issues/59
