### PR TITLE
Use npm@3 w/ node@4

### DIFF
--- a/kickstart/scripts/nodejs-deploy.sh
+++ b/kickstart/scripts/nodejs-deploy.sh
@@ -9,6 +9,8 @@ deploy_nodejs_ubuntu() {
   apt-get update
   apt-get install --no-install-recommends -y nodejs
 
+  npm install -g npm@~3.3.12
+
   npm install -g interp
 }
 


### PR DESCRIPTION
`node-pre-gyp` + `npm` 2 + `sudo` don't work well together, resulting in errors similar to:

```
> mapnik@3.5.8 preinstall /usr/lib/node_modules/tl/node_modules/tilelive-vector/node_modules/mapnik
> npm install node-pre-gyp

npm WARN package.json mapnik@3.5.8 No license field.
npm ERR! Linux 3.13.0-77-generic
npm ERR! argv "/usr/bin/nodejs" "/usr/bin/npm" "install" "node-pre-gyp"
npm ERR! node v4.4.2
npm ERR! npm  v2.15.0
npm ERR! path /home/posm/.npm/brace-expansion/1.1.3/package.tgz.2889632796
npm ERR! code EACCES
npm ERR! errno -13
npm ERR! syscall open

npm ERR! Error: EACCES: permission denied, open '/home/posm/.npm/brace-expansion/1.1.3/package.tgz.2889632796'
npm ERR!     at Error (native)
npm ERR!  { [Error: EACCES: permission denied, open '/home/posm/.npm/brace-expansion/1.1.3/package.tgz.2889632796']
npm ERR!   errno: -13,
ERR!   code: 'EACCES',
npm ERR!   syscall: 'open',
npm ERR!   path: '/home/posm/.npm/brace-expansion/1.1.3/package.tgz.2889632796',
npm ERR!   parent: 'minimatch' }
npm ERR!
npm ERR! Please try running this command again as root/Administrator.
-
npm ERR! Please include the following file with any support request:
npm ERR!     /usr/lib/node_modules/tl/node_modules/tilelive-vector/node_modules/mapnik/npm-debug.log
```

Switching to the flat `node_modules` structure used by `npm` 3 prevents these permissions problems from cropping up.

`npm@~3.3.12` is used because it's the last version that didn't error out manually installing modules into a globally-installed module's `node_modules` (AmericanRedCross/posm#69).
