### PR TITLE
Tuned postgresql.conf w/ dynamic memory settings

### DIFF
--- a/kickstart/etc/postgresql/postgresql.conf.local
+++ b/kickstart/etc/postgresql/postgresql.conf.local
@@ -1,0 +1,11 @@
+shared_preload_libraries = 'pg_stat_statements'
+pg_stat_statements.max = 100
+pg_stat_statements.track = top
+pg_stat_statements.save = off
+shared_buffers = {{shared_buffers}}MB # 25% of system memory
+effective_cache_size = {{effective_cache_size}}MB # 50% of system memory
+checkpoint_completion_target = 0.9
+random_page_cost = 2.0
+work_mem = 30MB
+maintenance_work_mem = 300MB
+max_stack_depth = 3MB

--- a/kickstart/scripts/postgis-deploy.sh
+++ b/kickstart/scripts/postgis-deploy.sh
@@ -11,10 +11,18 @@ deploy_postgis_ubuntu() {
   apt-get install --no-install-recommends -y \
     postgis \
     "postgresql-$pgsql_ver-postgis-$postgis_ver" \
-    "postgresql-$pgsql_ver-postgis-scripts"
+    "postgresql-$pgsql_ver-postgis-scripts" \
+    "postgresql-contrib-$pgsql_ver"
 
-  grep -q "0.0.0.0/0" /etc/postgresql/9.5/main/pg_hba.conf || \
-    echo "host	all	all	0.0.0.0/0	md5" >> /etc/postgresql/9.5/main/pg_hba.conf
+  grep -q "0.0.0.0/0" /etc/postgresql/${pgsql_ver}/main/pg_hba.conf || \
+    echo "host	all	all	0.0.0.0/0	md5" >> /etc/postgresql/${pgsql_ver}/main/pg_hba.conf
+
+  grep -q "postgresql.conf.local" /etc/postgresql/${pgsql_ver}/main/postgresql.conf || \
+    echo "include '/etc/postgresql/${pgsql_ver}/main/postgresql.conf.local'" >> /etc/postgresql/${pgsql_ver}/main/postgresql.conf
+
+  export shared_buffers=$(awk 'NR == 1 { print int($2*.25/1024) } ' /proc/meminfo)
+  export effective_cache_size=$(awk 'NR == 1 { print int($2*.5/1024) } ' /proc/meminfo)
+  expand etc/postgresql/postgresql.conf.local /etc/postgresql/${pgsql_ver}/main/postgresql.conf.local
 
   service postgresql restart
 }


### PR DESCRIPTION
Also makes path references vary according to target Postgres version.

`postgresql-contrib-$pgsql_ver` is necessary for `pg_stat_statements` to be available.

Fixes AmericanRedCross/posm#128
