### PR TITLE
Allow .io domains to resolve

### DIFF
--- a/kickstart/etc/dnsmasq-posm.conf
+++ b/kickstart/etc/dnsmasq-posm.conf
@@ -13,7 +13,6 @@ filterwin2k
 
 # Add local-only domains here, queries in these domains are answered
 # from /etc/hosts or DHCP only.
-local=/{{posm_domain}}/
 local=/{{lan_domain}}/
 
 # If you want dnsmasq to change uid and gid to something other


### PR DESCRIPTION
CNAME records (`cname=`) should be sufficient to handle resolution of posm-related hostnames.

Fixes AmericanRedCross/posm#158
