### PR TITLE
Start CGImap after Postgres

### DIFF
--- a/kickstart/etc/init.d/postgresql
+++ b/kickstart/etc/init.d/postgresql
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -e
+
+### BEGIN INIT INFO
+# Provides:		postgresql
+# Required-Start:	$local_fs $remote_fs $network $time
+# Required-Stop:	$local_fs $remote_fs $network $time
+# Should-Start:		$syslog
+# Should-Stop:		$syslog
+# Default-Start:	2 3 4 5
+# Default-Stop:		0 1 6
+# Short-Description:	PostgreSQL RDBMS server
+### END INIT INFO
+
+# Setting environment variables for the postmaster here does not work; please
+# set them in /etc/postgresql/<version>/<cluster>/environment instead.
+
+[ -r /usr/share/postgresql-common/init.d-functions ] || exit 0
+
+. /usr/share/postgresql-common/init.d-functions
+
+# versions can be specified explicitly
+if [ -n "$2" ]; then
+    versions="$2 $3 $4 $5 $6 $7 $8 $9"
+else
+    get_versions
+fi
+
+case "$1" in
+    start|stop|restart|reload)
+        if [ "$1" = "start" ]; then
+            create_socket_directory
+        fi
+	if [ -z "`pg_lsclusters -h`" ]; then
+	    log_warning_msg 'No PostgreSQL clusters exist; see "man pg_createcluster"'
+	    exit 0
+	fi
+	for v in $versions; do
+	    $1 $v || EXIT=$?
+	done
+	if [ "$1" = start -o "$1" = restart ]; then
+	    initctl emit -n started JOB=postgresql
+	fi
+	if [ "$1" = stop -o "$1" = restart ]; then
+	    initctl emit -n stopped JOB=postgresql
+	fi
+	exit ${EXIT:-0}
+        ;;
+    status)
+	LS=`pg_lsclusters -h`
+	# no clusters -> unknown status
+	[ -n "$LS" ] || exit 4
+	echo "$LS" | awk 'BEGIN {rc=0} {if (match($4, "down")) rc=3; printf ("%s/%s (port %s): %s\n", $1, $2, $3, $4)}; END {exit rc}'
+	;;
+    force-reload)
+	for v in $versions; do
+	    reload $v
+	done
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|reload|force-reload|status} [version ..]"
+        exit 1
+        ;;
+esac
+
+exit 0
+

--- a/kickstart/etc/osm-cgimap.upstart
+++ b/kickstart/etc/osm-cgimap.upstart
@@ -2,7 +2,7 @@
 
 description     "CGImap"
 
-start on (local-filesystems and net-device-up and runlevel [2345])
+start on started postgresql
 stop on shutdown
 
 env CGIMAP_BACKEND="apidb"

--- a/kickstart/scripts/postgis-deploy.sh
+++ b/kickstart/scripts/postgis-deploy.sh
@@ -24,6 +24,8 @@ deploy_postgis_ubuntu() {
   export effective_cache_size=$(awk 'NR == 1 { print int($2*.5/1024) } ' /proc/meminfo)
   expand etc/postgresql/postgresql.conf.local /etc/postgresql/${pgsql_ver}/main/postgresql.conf.local
 
+  expand etc/init.d/postgresql /etc/init.d/postgresql
+
   service postgresql restart
 }
 


### PR DESCRIPTION
This requires replacing the Postgres init script so that it notifies upstart about having started.

@hallahan encountered this recently, which reminded me that I had this partially written patch lying around (after having run into the same thing myself).
