### PR TITLE
'public' and 'fieldpapers' SMB shares

### DIFF
--- a/kickstart/etc/smb.conf
+++ b/kickstart/etc/smb.conf
@@ -1,0 +1,41 @@
+[global]
+  workgroup = POSM
+  server string = POSM
+  dns proxy = no
+  security = user
+  interfaces = wlan0
+  bind interfaces only = true
+  guest account = nobody
+
+  # Ubuntu defaults
+  log file = /var/log/samba/log.%m
+  max log size = 1000
+  syslog = 0
+  panic action = /usr/share/samba/panic-action %d
+  server role = standalone server
+  passdb backend = tdbsam
+  obey pam restrictions = yes
+  unix password sync = yes
+  passwd program = /usr/bin/passwd %u
+  passwd chat = *Enter\snew\s*\spassword:* %n\n *Retype\snew\s*\spassword:* %n\n *password\supdated\ssuccessfully* .
+  pam password change = yes
+  map to guest = bad user
+  usershare allow guests = yes
+
+[public]
+   comment = Public Data
+   path = /opt/data/public
+   browseable = yes
+   guest ok = yes
+   create mask = 0777
+   directory mask = 0777
+   writable = yes
+
+[fieldpapers]
+   comment = Field Papers
+   path = /opt/data/fieldpapers
+   browseable = yes
+   guest ok = yes
+   create mask = 0777
+   directory mask = 0777
+   writable = yes

--- a/kickstart/scripts/samba-deploy.sh
+++ b/kickstart/scripts/samba-deploy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+deploy_samba_ubuntu() {
+  apt-get install --no-install-recommends -y samba
+
+  mkdir -p /opt/data/public
+  chown nobody:nogroup /opt/data/public
+  chmod 777 /opt/data/public
+
+  mkdir -p /opt/data/fieldpapers
+  chown nobody:nogroup /opt/data/fieldpapers
+  chmod 777 /opt/data/fieldpapers
+
+  expand etc/smb.conf /etc/samba/smb.conf
+
+  service samba restart
+}
+
+deploy samba


### PR DESCRIPTION
This is a first pass at configuring Samba and making backup, etc. directories available via fileshare. As of this PR, there are 2 shares available:
- `public` - read/write for random purposes (leaving files for others)
- `fieldpapers` - to facilitate AmericanRedCross/posm#100

Backups made in AmericanRedCross/posm#141 can also be exposes so that they can easily be downloaded by connected devices.
