### PR TITLE
Configure openstreetmap-website POSM tile URLs

### DIFF
--- a/kickstart/scripts/osm-deploy.sh
+++ b/kickstart/scripts/osm-deploy.sh
@@ -74,6 +74,9 @@ deploy_osm_rails() {
 
   su - osm -c "cd '$dst/osm-web' && bundle exec rake db:migrate"
 
+  sed -i -e "s/posm.io/${posm_fqdn}/" vendor/assets/iD/imagery.js
+  sed -i -e "s/posm.io/${posm_fqdn}/" app/assets/javascripts/leaflet.map.js
+
   # assets
   su - osm -c "cd '$dst/osm-web' && bundle exec rake assets:precompile"
 


### PR DESCRIPTION
This allows hostnames other than `posm.io` to work.
