### PR TITLE
Use the xenial version of osm2pgsql

### DIFF
--- a/kickstart/scripts/osm-deploy.sh
+++ b/kickstart/scripts/osm-deploy.sh
@@ -135,7 +135,7 @@ deploy_osm_ubuntu() {
     osmpbf-bin libosmpbf-dev
 
   type osmconvert || ubuntu_backport_install osmctools
-  type osm2pgsql || ubuntu_backport_install osm2pgsql
+  type osm2pgsql || ubuntu_backport_install osm2pgsql xenial
   deploy_osmosis_prebuilt
 
   deploy_osm_rails_ubuntu


### PR DESCRIPTION
After the appearance of yakkety yak, backportpackage began trying to build 16.10's osm2pgsql (0.90), which includes dependencies that can't be resolved. This pins the backported version to xenial, which is 0.88.

The failure to backport osm2pgsql-0.90 was resulting in the version shipped in trusty (0.82) being installed, which didn't include support (at least in the way we expected) to --extra-attributes.

Fixes AmericanRedCross/posm#129
