### PR TITLE
Provide an environment file for posm-carto

### DIFF
--- a/kickstart/etc/posm-carto.env
+++ b/kickstart/etc/posm-carto.env
@@ -1,0 +1,1 @@
+DATABASE_URL="postgres://{{osm_carto_pg_owner}}:{{osm_carto_pg_pass}}@localhost/{{osm_carto_pg_dbname}}"

--- a/kickstart/etc/posm.json
+++ b/kickstart/etc/posm.json
@@ -29,5 +29,6 @@
   "osm_pg_pass": "{{osm_pg_pass}}",
   "osm_pg_dbname": "{{osm_pg_dbname}}",
   "osm_carto_pg_dbname": "{{osm_carto_pg_dbname}}",
-  "osm_carto_pg_owner": "{{osm_carto_pg_owner}}"
+  "osm_carto_pg_owner": "{{osm_carto_pg_owner}}",
+  "osm_carto_pg_pass": "{{osm_carto_pg_pass}}"
 }

--- a/kickstart/etc/settings
+++ b/kickstart/etc/settings
@@ -50,6 +50,7 @@ osm_carto_pg_dbname="gis"
 osm_carto_pg_temp_dbname="gis_temp"
 osm_carto_pg_owner="gis"
 osm_carto_pg_users="root fp omk"
+osm_carto_pg_pass="openstreetmap"
 
 # tile styles [posm, osm]
 carto_styles="posm"

--- a/kickstart/scripts/carto-deploy.sh
+++ b/kickstart/scripts/carto-deploy.sh
@@ -30,6 +30,9 @@ deploy_carto_posm() {
   from_github "https://github.com/AmericanRedCross/posm-carto" "$dst/posm-carto"
   chown -R "$carto_user:$carto_user" "$dst/posm-carto"
 
+  expand etc/posm-carto.env "$dst/posm-carto/.env"
+  chown $carto_user:$carto_user "$dst/posm-carto/.env"
+
   su - "$carto_user" -c "cd '$dst/posm-carto' && npm install --quiet"
   su - "$carto_user" -c "make -C '$dst/posm-carto' project.xml"
 


### PR DESCRIPTION
https://github.com/AmericanRedCross/posm-carto/commit/01676be80bf51b0b6d9dd9212259dc1991b7ab27 added a dependency on `DATABASE_URL` (which should have already been present), so this ensures that one is available.

This has the side-effect of fixing AmericanRedCross/posm#114 and assigning a password to the `gis` user.
