### PR TITLE
Allow batch uploading by copying over SMB

### DIFF
--- a/kickstart/etc/fp-watch.sh
+++ b/kickstart/etc/fp-watch.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+DATA_DIR=/opt/data/fieldpapers
+PENDING_DIR=/opt/data/fieldpapers/pending
+SNAPSHOTS_DIR=/opt/data/fieldpapers/snapshots
+fp_api_base_url=$(jq -r .fp_api_base_url /etc/posm.json)
+
+mkdir -p "$PENDING_DIR"
+mkdir -p "$SNAPSHOTS_DIR"
+chown fp:fp "$PENDING_DIR"
+chown fp:fp "$SNAPSHOTS_DIR"
+
+inotifywait -q -m -e close_write --format '%w%f' "$DATA_DIR" | while read filename; do
+    # ignore data in folders
+    if [ "$(dirname $filename)" != "$DATA_DIR" ]; then
+      continue
+    fi
+
+    # is it empty?
+    test -s $filename || continue
+
+    # does anything have it open?
+    fuser $filename > /dev/null 2>&1 && continue
+
+    case "$filename" in
+        # ignore OSX-style metadata
+        *._*)
+            continue
+
+           ;;
+
+        *.[Pp][Dd][Ff]|*.[Pp][Nn][Gg]|*.[Jj][Pp][Ee]?[Gg])
+            echo "Uploading ${filename}..."
+
+            fn=$(basename $filename)
+            pending="${PENDING_DIR}/${fn}"
+
+            # copy it into a staging directory
+            mv $filename "$PENDING_DIR"
+            # delete OS X metadata (if present)
+            rm -f ${DATA_DIR}/._${fn}
+
+            # upload to FP
+            snapshot_url=$(curl -sF "snapshot[scene]=@${pending};type=$(file -b --mime-type ${pending})" ${fp_api_base_url}/snapshots -o /dev/null -w "%{redirect_url}")
+
+            IFS=/ read -a parts <<< "$snapshot_url"
+            snapshot_id=${parts[5]}
+
+            mv $pending "${SNAPSHOTS_DIR}/${snapshot_id}-${fn}"
+
+            echo "Snapshot URL: ${snapshot_url}"
+
+            ;;
+    esac
+done

--- a/kickstart/etc/fp-watch.upstart
+++ b/kickstart/etc/fp-watch.upstart
@@ -1,0 +1,25 @@
+# fp-watch
+
+description     "Field Papers Watcher"
+
+start on (local-filesystems and net-device-up and runlevel [2345])
+stop on shutdown
+
+respawn
+#respawn limit 5 60
+
+pre-start script
+    echo "[`date '+%c'`] Starting: fp-watch" >> /var/log/fp-watch.log
+end script
+
+pre-stop script
+    echo "[`date '+%c'`] Stopping: fp-watch" >> /var/log/fp-watch.log
+end script
+
+exec start-stop-daemon \
+		--start \
+		--chdir /opt/fp \
+		--chuid fp \
+		--make-pidfile \
+		--pidfile /var/run/fp-watch.pid \
+		--exec /opt/fp/bin/fp-watch.sh >> /var/log/fp-watch.log 2>&1

--- a/kickstart/scripts/fieldpapers-deploy.sh
+++ b/kickstart/scripts/fieldpapers-deploy.sh
@@ -22,7 +22,8 @@ deploy_fieldpapers_ubuntu() {
     python-software-properties \
     ruby2.2-dev \
     sqlite3 \
-    zlib1g-dev
+    zlib1g-dev \
+    inotify-tools
 
   # FP user & env
   useradd -c 'Field Papers' -d "$dst" -m -r -s /bin/bash -U fp
@@ -50,6 +51,15 @@ deploy_fieldpapers_common() {
   deploy_fp_tiler
   deploy_fp_tasks
   deploy_fp_legacy
+
+  mkdir -p "$dst/bin"
+  expand etc/fp-watch.sh "$dst/bin/fp-watch.sh"
+  chmod +x "$dst/bin/fp-watch.sh"
+  chown -R fp:fp "$dst/bin"
+
+  expand etc/fp-watch.upstart /etc/init/fp-watch.conf
+
+  service fp-watch restart
 }
 
 deploy_fp_web() {


### PR DESCRIPTION
This implements an `inotify`-based watcher that keeps an eye on images that are copied into `/opt/data/fieldpapers` (SMB share: `//POSM/fieldpapers`) and uploads them to the local instance of Field Papers. Files will be moved into a `snapshots/` directory, prefixed with the snapshot ID once they've been uploaded. They're also visible on the Field Papers "watch" tab.

Fixes AmericanRedCross/posm#100
