### PR TITLE
Disable netbios

### DIFF
--- a/kickstart/etc/smb.conf
+++ b/kickstart/etc/smb.conf
@@ -6,6 +6,7 @@
   interfaces = wlan0
   bind interfaces only = true
   guest account = nobody
+  disable netbios = yes
 
   # Ubuntu defaults
   log file = /var/log/samba/log.%m


### PR DESCRIPTION
This allows POSM shares to be browsed via the OS X network explorer.

per http://www.tenforums.com/network-sharing/31136-samba-shares-dont-show-up-windows-10-network-2.html, disabled netbios, restarted Samba, and boom.

/cc @hallahan 
