### PR TITLE
Switch to EFI-only booting

### DIFF
--- a/kickstart/POSM_Server_USB.cfg
+++ b/kickstart/POSM_Server_USB.cfg
@@ -42,10 +42,6 @@ d-i partman/mount_style select uuid
 d-i partman-auto/disk string /dev/sda
 d-i partman-auto/expert_recipe string                         \
       boot-root ::                                            \
-              1 1 1 free                                      \
-                      $bios_boot{ }                           \
-                      method{ biosgrub }                      \
-              .                                               \
               512 1024 512 fat32                              \
                       $primary{ }                             \
                       $lvmignore{ }                           \
@@ -53,29 +49,35 @@ d-i partman-auto/expert_recipe string                         \
                       format{ }                               \
               .                                               \
               256 2048 256 ext2                               \
-                      $primary{ } $bootable{ }                \
-                      method{ format } format{ }              \
-                      use_filesystem{ } filesystem{ ext2 }    \
+                      $primary{ }                             \
+                      method{ format }                        \
+                      format{ }                               \
+                      use_filesystem{ }                       \
+                      filesystem{ ext2 }                      \
                       mountpoint{ /boot }                     \
               .                                               \
               4096 4096 8192 linux-swap                       \
                       $primary{ }                             \
-                      method{ swap } format{ }                \
+                      method{ swap }                          \
+                      format{ }                               \
               .                                               \
               4096 10240 12288 ext4                           \
-                      method{ format } format{ }              \
+                      method{ format }                        \
+                      format{ }                               \
                       use_filesystem{ }                       \
                       filesystem{ ext4 }                      \
                       mountpoint{ / }                         \
               .                                               \
-              8192 8192 8192 ext4                             \
-                      method{ format } format{ }              \
+              8192 16384 32768 ext4                           \
+                      method{ format }                        \
+                      format{ }                               \
                       use_filesystem{ }                       \
                       filesystem{ ext4 }                      \
                       mountpoint{ /var }                      \
               .                                               \
-              8192 12288 100000000 ext4                       \
-                      method{ format } format{ }              \
+              8192 12288 -1 ext4                              \
+                      method{ format }                        \
+                      format{ }                               \
                       use_filesystem{ }                       \
                       filesystem{ ext4 }                      \
                       mountpoint{ /opt }                      \
@@ -123,8 +125,8 @@ d-i pkgsel/update-policy select unattended-upgrades
 popularity-contest popularity-contest/participate boolean false
 
 ### Boot loader installation
-d-i grub-installer/only_debian boolean true
-d-i grub-installer/with_other_os boolean true
+# d-i grub-installer/only_debian boolean true
+# d-i grub-installer/with_other_os boolean true
 # see grub-md5-crypt(8)
 #d-i grub-installer/password-crypted password $1$ugsWY$53CnqTxpbgGJiKv2xRTYu/
 #d-i debian-installer/add-kernel-opts string nousb


### PR DESCRIPTION
This also drops the bootable flag from `/dev/sda2`, which was likely confusing Clonezilla's `efibootmgr` updates.

It also increases the size of `/var` to account for large regions (Sierra Leone, Liberia, and Guinea).
