### PR TITLE
Clear apt proxy settings (if provided)

### DIFF
--- a/kickstart/POSM_Server_USB.cfg
+++ b/kickstart/POSM_Server_USB.cfg
@@ -185,6 +185,7 @@ d-i preseed/late_command string \
 		admin \
 		samba \
 		wifi; \
+	in-target truncate /etc/apt/apt.conf; \
 	true
 
 #d-i preseed/include/checksum string xxx


### PR DESCRIPTION
I use a local proxy server (`polipo`) when provisioning so that it doesn't need to download everything from the Internet. However, if the intent is for devices to be sent into the field (or imaged onto other devices), they probably won't have the same cache server available.

This particular preseed configuration only adds proxy settings to `/etc/apt/apt.conf`, so truncating it is the quickest way to clear the settings.
