### PR TITLE
Better Intel wifi support (NUC standard)

### DIFF
--- a/kickstart/etc/hostapd.conf
+++ b/kickstart/etc/hostapd.conf
@@ -420,7 +420,7 @@ ap_max_inactivity=600
 # 0 = disabled (default)
 # 1 = enabled
 # Note: You will also need to enable WMM for full HT functionality.
-ieee80211n=1
+ieee80211n={{posm_wifi_80211n}}
 
 # ht_capab: HT capabilities (list of flags)
 # LDPC coding capability: [LDPC] = supported

--- a/kickstart/etc/hostapd.conf
+++ b/kickstart/etc/hostapd.conf
@@ -985,7 +985,7 @@ own_ip_addr=127.0.0.1
 # bit0 = WPA
 # bit1 = IEEE 802.11i/RSN (WPA2) (dot11RSNAEnabled)
 # comment this out if you want an open network
-wpa=2
+wpa={{posm_wifi_wpa}}
 
 # WPA pre-shared keys for WPA-PSK. This can be either entered as a 256-bit
 # secret in hex format (64 hex digits), wpa_psk, or as an ASCII passphrase

--- a/kickstart/etc/hostapd.conf
+++ b/kickstart/etc/hostapd.conf
@@ -456,7 +456,7 @@ ieee80211n=1
 # PSMP support: [PSMP] (disabled if not set)
 # L-SIG TXOP protection support: [LSIG-TXOP-PROT] (disabled if not set)
 #ht_capab=[HT40-][SHORT-GI-20][SHORT-GI-40]
-ht_capab=[HT40+][SHORT-GI-20][SHORT-GI-40][TX-STBC][RX-STBC1][DSSS_CCK-40]
+ht_capab=[HT40+][LDPC][SHORT-GI-20][SHORT-GI-40][TX-STBC][RX-STBC1][DSSS_CCK-40]
 
 # Require stations to support HT PHY (reject association if they do not)
 #require_ht=1

--- a/kickstart/etc/settings
+++ b/kickstart/etc/settings
@@ -10,6 +10,7 @@ posm_netif="wlan0"
 posm_ssid="POSM"
 posm_wpa_passphrase="awesomeposm" # 8..63 characters
 posm_wifi_channel="1"
+posm_wifi_80211n="0" # set to 1 to enable 802.11n (e.g. ath9k)
 posm_hostname="posm"
 posm_domain="io"
 lan_domain="lan"

--- a/kickstart/etc/settings
+++ b/kickstart/etc/settings
@@ -11,6 +11,7 @@ posm_ssid="POSM"
 posm_wpa_passphrase="awesomeposm" # 8..63 characters
 posm_wifi_channel="1"
 posm_wifi_80211n="0" # set to 1 to enable 802.11n (e.g. ath9k)
+posm_wifi_wpa="2" # set to 0 to disable passwords
 posm_hostname="posm"
 posm_domain="io"
 lan_domain="lan"


### PR DESCRIPTION
This allows 802.11n mode to be configured (defaults to off in `settings`). Since it's disabled by default, `LDPC` is re-enabled for other cards.

This also adds the ability to disable WPA authentication by setting `posm_wifi_wpa=0` (defaults to `2`, which is secured).
