### PR TITLE
Support a second physical network interface

### DIFF
--- a/kickstart/etc/disable-port-forwarding
+++ b/kickstart/etc/disable-port-forwarding
@@ -3,9 +3,11 @@
 # ifdown hook script to disable port forwarding
 
 case "$IFACE" in
-  {{posm_netif}}) exit 0 ;;
+  {{posm_wlan_netif}}) exit 0 ;;
+  {{posm_lan_netif}}) exit 0 ;;
 esac
 
 iptables -t nat -D POSTROUTING -o $IFACE -j MASQUERADE
 iptables -D FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-iptables -D FORWARD -i {{posm_netif}} -o $IFACE -j ACCEPT
+iptables -D FORWARD -i {{posm_wlan_netif}} -o $IFACE -j ACCEPT
+iptables -D FORWARD -i {{posm_lan_netif}} -o $IFACE -j ACCEPT

--- a/kickstart/etc/dnsmasq-captive.conf
+++ b/kickstart/etc/dnsmasq-captive.conf
@@ -1,2 +1,2 @@
 # Set wildcard address (anything not in /etc/hosts, leases, or set above)
-address=/#/{{posm_ip}}
+address=/#/{{posm_wlan_ip}}

--- a/kickstart/etc/dnsmasq-posm.conf
+++ b/kickstart/etc/dnsmasq-posm.conf
@@ -49,14 +49,15 @@ cname={{osm_fqdn}},{{posm_fqdn}}
 # 2) Sets the "domain" DHCP option thereby potentially setting the
 #    domain of all systems configured by DHCP
 # 3) Provides the domain part for "expand-hosts"
-domain={{lan_domain}},{{posm_subnet}}.0/24
+domain={{lan_domain}},{{posm_network}}.0.0/16
 
 # Uncomment this to enable the integrated DHCP server, you need
 # to supply the range of addresses available for lease and optionally
 # a lease time. If you have more than one network, you will need to
 # repeat this for each network on which you want to supply DHCP
 # service.
-dhcp-range={{posm_subnet}}.16,{{posm_subnet}}.223,255.255.255.0,12h
+dhcp-range=interface:{{posm_wlan_netif}},{{posm_wlan_subnet}}.10,{{posm_wlan_subnet}}.250,12h
+dhcp-range=interface:{{posm_lan_netif}},{{posm_lan_subnet}}.10,{{posm_lan_subnet}}.250,12h
 
 # If this line is uncommented, dnsmasq will read /etc/ethers and act
 # on the ethernet-address/IP pairs found there just as if they had

--- a/kickstart/etc/dnsmasq-posm.conf
+++ b/kickstart/etc/dnsmasq-posm.conf
@@ -22,7 +22,7 @@ local=/{{lan_domain}}/
 
 # Which interface to listen on by address (remember to include
 # 127.0.0.1 if you use this.)
-listen-address=127.0.0.1,{{posm_ip}}
+listen-address=127.0.0.1,{{posm_wlan_ip}},{{posm_lan_ip}}
 
 # If you don't want dnsmasq to read /etc/hosts, uncomment the
 # following line.
@@ -37,10 +37,10 @@ expand-hosts
 cname={{osm_fqdn}},{{posm_fqdn}}
 
 # Set fixed addresses (A records)
-#address=/posm.io/{{posm_ip}}
+#address=/posm.io/{{posm_wlan_ip}}
 
 # Set wildcard address (anything not in /etc/hosts, leases, or set above)
-# address=/#/{{posm_ip}}
+# address=/#/{{posm_wlan_ip}}
 
 # Set the domain for dnsmasq. this is optional, but if it is set, it
 # does the following things.

--- a/kickstart/etc/enable-port-forwarding
+++ b/kickstart/etc/enable-port-forwarding
@@ -3,9 +3,11 @@
 # ifup hook script to enable port forwarding
 
 case "$IFACE" in
-  {{posm_netif}}) exit 0 ;;
+  {{posm_wlan_netif}}) exit 0 ;;
+  {{posm_lan_netif}}) exit 0 ;;
 esac
 
 iptables -t nat -C POSTROUTING -o $IFACE -j MASQUERADE 2> /dev/null || iptables -t nat -A POSTROUTING -o $IFACE -j MASQUERADE
 iptables -C FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2> /dev/null || iptables -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-iptables -C FORWARD -i {{posm_netif}} -o $IFACE -j ACCEPT 2> /dev/null || iptables -A FORWARD -i {{posm_netif}} -o $IFACE -j ACCEPT
+iptables -C FORWARD -i {{posm_wlan_netif}} -o $IFACE -j ACCEPT 2> /dev/null || iptables -A FORWARD -i {{posm_wlan_netif}} -o $IFACE -j ACCEPT
+iptables -C FORWARD -i {{posm_lan_netif}} -o $IFACE -j ACCEPT 2> /dev/null || iptables -A FORWARD -i {{posm_lan_netif}} -o $IFACE -j ACCEPT

--- a/kickstart/etc/hostapd.conf
+++ b/kickstart/etc/hostapd.conf
@@ -3,7 +3,7 @@
 
 # AP netdevice name (without 'ap' postfix, i.e., wlan0 uses wlan0ap for
 # management frames); ath0 for madwifi
-interface={{posm_netif}}
+interface={{posm_wlan_netif}}
 
 # In case of madwifi, atheros, and nl80211 driver interfaces, an additional
 # configuration parameter, bridge, may be used to notify hostapd if the

--- a/kickstart/etc/hosts
+++ b/kickstart/etc/hosts
@@ -3,4 +3,4 @@
 ff02::1         ip6-allnodes
 ff02::2         ip6-allrouters
 
-{{posm_ip}}   {{posm_fqdn}} {{posm_hostname}}.{{lan_domain}}
+{{posm_wlan_ip}}   {{posm_fqdn}} {{posm_hostname}}.{{lan_domain}}

--- a/kickstart/etc/network-interfaces
+++ b/kickstart/etc/network-interfaces
@@ -1,14 +1,19 @@
 auto lo
 iface lo inet loopback
 
-auto {{posm_netif}}
-iface {{posm_netif}} inet static
-  address {{posm_ip}}
+auto {{posm_wlan_netif}}
+iface {{posm_wlan_netif}} inet static
+  address {{posm_wlan_ip}}
   netmask 255.255.255.0
   hostapd /etc/hostapd/hostapd.conf
 
 allow-hotplug {{posm_wan_netif}}
 iface {{posm_wan_netif}} inet dhcp
+
+auto {{posm_lan_netif}}
+iface {{posm_lan_netif}} inet static
+  address {{posm_lan_ip}}
+  netmask 255.255.255.0
 
 # Android tethering
 allow-hotplug usb0

--- a/kickstart/etc/network-interfaces
+++ b/kickstart/etc/network-interfaces
@@ -4,7 +4,7 @@ iface lo inet loopback
 auto {{posm_wlan_netif}}
 iface {{posm_wlan_netif}} inet static
   address {{posm_wlan_ip}}
-  netmask 255.255.255.0
+  netmask 255.255.0.0
   hostapd /etc/hostapd/hostapd.conf
 
 allow-hotplug {{posm_wan_netif}}
@@ -13,7 +13,7 @@ iface {{posm_wan_netif}} inet dhcp
 auto {{posm_lan_netif}}
 iface {{posm_lan_netif}} inet static
   address {{posm_lan_ip}}
-  netmask 255.255.255.0
+  netmask 255.255.0.0
 
 # Android tethering
 allow-hotplug usb0

--- a/kickstart/etc/nginx-posm.conf
+++ b/kickstart/etc/nginx-posm.conf
@@ -1,6 +1,6 @@
 server {
   listen 80;
-  server_name {{posm_hostname}} {{posm_hostname}}.local {{posm_hostname}}.{{lan_domain}} {{posm_fqdn}} {{posm_ip}};
+  server_name {{posm_hostname}} {{posm_hostname}}.local {{posm_hostname}}.{{lan_domain}} {{posm_fqdn}} {{posm_wlan_ip}};
 
   proxy_buffering off;
   proxy_http_version 1.1;

--- a/kickstart/etc/posm.json
+++ b/kickstart/etc/posm.json
@@ -1,9 +1,11 @@
 {
   "posm_env": "{{posm_env}}",
   "posm_subnet": "{{posm_subnet}}",
-  "posm_ip": "{{posm_ip}}",
+  "posm_lan_ip": "{{posm_lan_ip}}",
+  "posm_wlan_ip": "{{posm_wlan_ip}}",
   "posm_wan_netif": "{{posm_wan_netif}}",
-  "posm_netif": "{{posm_netif}}",
+  "posm_lan_netif": "{{posm_lan_netif}}",
+  "posm_wlan_netif": "{{posm_wlan_netif}}",
   "posm_ssid": "{{posm_ssid}}",
   "posm_wpa_passphrase": "{{posm_wpa_passphrase}}",
   "posm_wifi_channel": "{{posm_wifi_channel}}",

--- a/kickstart/etc/posm.json
+++ b/kickstart/etc/posm.json
@@ -1,6 +1,8 @@
 {
   "posm_env": "{{posm_env}}",
-  "posm_subnet": "{{posm_subnet}}",
+  "posm_network": "{{posm_network}}",
+  "posm_wlan_subnet": "{{posm_wlan_subnet}}",
+  "posm_lan_subnet": "{{posm_lan_subnet}}",
   "posm_lan_ip": "{{posm_lan_ip}}",
   "posm_wlan_ip": "{{posm_wlan_ip}}",
   "posm_wan_netif": "{{posm_wan_netif}}",

--- a/kickstart/etc/settings
+++ b/kickstart/etc/settings
@@ -3,9 +3,11 @@
 posm_env=production
 
 # network
-posm_subnet="192.168.6" # always a Class-C /24
-posm_wlan_ip="$posm_subnet.1"
-posm_lan_ip="$posm_subnet.2"
+posm_network="172.16" # class B
+posm_wlan_subnet="$posm_network.1"
+posm_lan_subnet="$posm_network.2"
+posm_wlan_ip="$posm_wlan_subnet.1"
+posm_lan_ip="$posm_lan_subnet.1"
 posm_wan_netif="p2p1"
 posm_lan_netif="eth1"
 posm_wlan_netif="wlan0"

--- a/kickstart/etc/settings
+++ b/kickstart/etc/settings
@@ -4,9 +4,11 @@ posm_env=production
 
 # network
 posm_subnet="192.168.6" # always a Class-C /24
-posm_ip="$posm_subnet.1"
+posm_wlan_ip="$posm_subnet.1"
+posm_lan_ip="$posm_subnet.2"
 posm_wan_netif="p2p1"
-posm_netif="wlan0"
+posm_lan_netif="eth1"
+posm_wlan_netif="wlan0"
 posm_ssid="POSM"
 posm_wpa_passphrase="awesomeposm" # 8..63 characters
 posm_wifi_channel="1"


### PR DESCRIPTION
E.g. `eth1`, which would be used for a LAN port, i.e. to be plugged into a switch to support wired clients.

Also renames `posm_{netif,ip}` to `posm_wlan_{netif,ip}` for clarity.

Not ready for merging yet, as having `eth1` active causes problems with DHCP over `wlan0` (specifically `DHCPDISCOVER` / `DHCPOFFER`s without corresponding `DHCPACK`s. `ifconfig eth1 down` solves the problem. Meanwhile, DHCP clients on `eth1` are fine.
