### PR TITLE
HTTP Proxy + Autodiscovery

### DIFF
--- a/kickstart/etc/dnsmasq-00proxy.conf
+++ b/kickstart/etc/dnsmasq-00proxy.conf
@@ -1,0 +1,2 @@
+dhcp-option=252,http://wpad.{{lan_domain}}/wpad.dat
+cname=wpad,{{posm_fqdn}}

--- a/kickstart/etc/dnsmasq-00proxy.conf
+++ b/kickstart/etc/dnsmasq-00proxy.conf
@@ -1,2 +1,1 @@
-dhcp-option=252,http://wpad.{{lan_domain}}/wpad.dat
-cname=wpad,{{posm_fqdn}}
+dhcp-option=252,"http://wpad.{{lan_domain}}/wpad.dat"

--- a/kickstart/etc/dnsmasq-posm.conf
+++ b/kickstart/etc/dnsmasq-posm.conf
@@ -89,7 +89,7 @@ dhcp-option=option:ntp-server,0.0.0.0
 #dhcp-option=46,8           # netbios node type
 
 # Send an empty WPAD option. This may be REQUIRED to get windows 7 to behave.
-dhcp-option=252,"\n"
+#dhcp-option=252,"\n"
 
 # Send RFC-3397 DNS domain search DHCP option. WARNING: Your DHCP client
 # probably doesn't support this......

--- a/kickstart/etc/hosts
+++ b/kickstart/etc/hosts
@@ -1,5 +1,5 @@
 127.0.0.1       localhost
-{{posm_wlan_ip}}      {{posm_fqdn}} {{osm_fqdn}} {{posm_hostname}}.{{lan_domain}} {{posm_hostname}}
+{{posm_wlan_ip}}      {{posm_fqdn}} {{osm_fqdn}} {{posm_hostname}}.{{lan_domain}} {{posm_hostname}} wpan.{{lan_domain}} wpad
 ::1             localhost ip6-localhost ip6-loopback
 ff02::1         ip6-allnodes
 ff02::2         ip6-allrouters

--- a/kickstart/etc/nginx-posm.conf
+++ b/kickstart/etc/nginx-posm.conf
@@ -80,6 +80,11 @@ server {
   location /fp/_/ {
     alias /opt/fp/data/;
   }
+
+  location /wpad.dat {
+    return 200 'function FindProxyForURL(url, host) {\n  if (shExpMatch(host, "{{posm_fqdn}}")) {\n    return "DIRECT";\n  }\n\n  return "PROXY {{posm_wlan_ip}}:1080; DIRECT";\n}';
+    add_header Content-Type application/x-ns-proxy-autoconfig;
+  }
 }
 
 # vim: set sts=2 sw=2 et si nu:

--- a/kickstart/etc/nginx-posm.conf
+++ b/kickstart/etc/nginx-posm.conf
@@ -82,7 +82,7 @@ server {
   }
 
   location /wpad.dat {
-    return 200 'function FindProxyForURL(url, host) {\n  if (shExpMatch(host, "{{posm_fqdn}}")) {\n    return "DIRECT";\n  }\n\n  return "PROXY {{posm_wlan_ip}}:1080; DIRECT";\n}';
+    return 200 'function FindProxyForURL(url, host) {\n  if (shExpMatch(host.toLowerCase(), "*.{{posm_fqdn}}") || isInNet(dnsResolve(host), "{{posm_network}}.0.0",  "255.240.0.0")) {\n    return "DIRECT";\n  }\n\n  return "PROXY {{posm_wlan_ip}}:1080";\n}';
     add_header Content-Type application/x-ns-proxy-autoconfig;
   }
 }

--- a/kickstart/etc/polipo/config
+++ b/kickstart/etc/polipo/config
@@ -1,0 +1,4 @@
+logSyslog = true
+logFile = /var/log/polipo/polipo.log
+proxyAddress = ::0
+proxyPort = 1080

--- a/kickstart/scripts/proxy-deploy.sh
+++ b/kickstart/scripts/proxy-deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+deploy_proxy_ubuntu() {
+  apt-get install --no-install-recommends -y polipo
+
+  expand etc/polipo/config /etc/polipo/config
+  expand etc/dnsmasq-00proxy.conf /etc/dnsmasq.d/00-proxy.conf
+
+  service polipo restart
+  service dnsmasq restart
+}
+
+deploy proxy


### PR DESCRIPTION
This adds support for [WPAD](https://en.wikipedia.org/wiki/Web_Proxy_Autodiscovery_Protocol) and makes a Proxy Auto-Config available at http://wpad.lan/wpad.dat (also http://posm.io/wpad.dat).

The underlying HTTP proxy is [polipo](https://github.com/jech/polipo), a lightweight caching proxy server.
