### PR TITLE
Upgrade kernel to 4.4.0 (lts-xenial)

### DIFF
--- a/kickstart/POSM_Server.cfg
+++ b/kickstart/POSM_Server.cfg
@@ -66,7 +66,7 @@ d-i partman-partitioning/confirm_write_new_label boolean true
 
 ### Base system installation
 #d-i base-installer/kernel/image string linux-generic
-d-i base-installer/kernel/image string linux-image-3.19.0-42-generic
+d-i base-installer/kernel/image string linux-image-generic-lts-xenial
 
 ### Account setup
 d-i passwd/root-login boolean true

--- a/kickstart/POSM_Server_USB.cfg
+++ b/kickstart/POSM_Server_USB.cfg
@@ -91,7 +91,7 @@ d-i partman-partitioning/confirm_write_new_label boolean true
 
 ### Base system installation
 #d-i base-installer/kernel/image string linux-generic
-d-i base-installer/kernel/image string linux-image-3.19.0-42-generic
+d-i base-installer/kernel/image string linux-image-generic-lts-xenial
 
 ### Account setup
 d-i passwd/root-login boolean true

--- a/kickstart/scripts/virt-deploy.sh
+++ b/kickstart/scripts/virt-deploy.sh
@@ -7,7 +7,7 @@ deploy_virt_ubuntu() {
   local v="`virt-what 2>/dev/null`"
   if [ $? = 0 ] && [ -n "$v" ]; then
     apt-get install --no-install-recommends -y \
-      linux-virtual \
+      linux-virtual-lts-xenial/ \
       open-vm-tools
   fi
 }

--- a/kickstart/scripts/wifi-deploy.sh
+++ b/kickstart/scripts/wifi-deploy.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
 
-# Should use Ubuntu linux-image-3.19.0-42-generic
 deploy_wifi_ubuntu() {
-	apt-get install --no-install-recommends -y linux-image-3.19.0-42-generic linux-image-extra-3.19.0-42-generic linux-firmware wireless-tools
-
-	ln -sf /lib/firmware/iwlwifi-7265D-12.ucode /lib/firmware/iwlwifi-3165-9.ucode
-	ln -sf /lib/firmware/iwlwifi-7265-12.ucode /lib/firmware/iwlwifi-3165-12.ucode
+  apt-get install --no-install-recommends -y linux-image-generic-lts-xenial wireless-tools
 
   apt-get remove --purge -y \
     network-manager


### PR DESCRIPTION
Adds support for Intel 8260 wireless chipsets present in NUC6i7KYK (Skull Canyon).

Workarounds for NUC5PPYH (`consoleblank=0`, driver symlinks) are no longer necessary with the newer kernel. Tested with both ath9k and Intel 3165 wireless cards.
