### PR TITLE
Disable IPv6 correctly

### DIFF
--- a/kickstart/scripts/wifi-deploy.sh
+++ b/kickstart/scripts/wifi-deploy.sh
@@ -11,7 +11,7 @@ deploy_wifi_ubuntu() {
     network-manager
 
   # disable IPv6
-  expand etc/sysctl.d/50-disable_ipv6.conf
+  expand etc/sysctl.d/50-disable_ipv6.conf /etc/sysctl.d/50-disable_ipv6.conf
 
   service procps start
 


### PR DESCRIPTION
Not that IPv6 has been causing any problems that I've seen recently.

This was originally added because IPv6 being enabled would cause slow `apt update`s, cf http://askubuntu.com/questions/272796/connecting-to-archive-ubuntu-com-takes-too-long
