### PR TITLE
Use variables for Samba network interfaces

### DIFF
--- a/kickstart/etc/smb.conf
+++ b/kickstart/etc/smb.conf
@@ -3,7 +3,7 @@
   server string = POSM
   dns proxy = no
   security = user
-  interfaces = wlan0
+  interfaces = lo {{posm_wlan_netif}} {{posm_lan_netif}}
   bind interfaces only = true
   guest account = nobody
   disable netbios = yes


### PR DESCRIPTION
Whitelists additional appropriate interfaces.
