### PR TITLE
Permit root logins with passwords

### DIFF
--- a/kickstart/scripts/base-deploy.sh
+++ b/kickstart/scripts/base-deploy.sh
@@ -19,6 +19,9 @@ deploy_base_ubuntu() {
 
   curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 -o /usr/local/bin/jq
   chmod +x /usr/local/bin/jq
+
+  sed -i 's/^PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+  sed -i 's/^PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
 }
 
 deploy_base_rhel() {


### PR DESCRIPTION
Primarily intended for devices, so this really belongs in the installer.
