### PR TITLE
Samba shares for OpenDroneMap

### DIFF
--- a/kickstart/etc/smb.conf
+++ b/kickstart/etc/smb.conf
@@ -41,6 +41,30 @@
    directory mask = 0777
    writable = yes
 
+[odm-input]
+   comment = OpenDroneMap input images
+   path = /opt/data/odm-input
+   browseable = yes
+   guest ok = yes
+   create mask = 0777
+   directory mask = 0777
+   writable = yes
+
+[aerial-imagery]
+   comment = OpenDroneMap-produced artifacts + GeoTIFF inputs
+   path = /opt/data/aerial-imagery
+   browseable = yes
+   guest ok = yes
+   create mask = 0777
+   directory mask = 0777
+   writable = yes
+
+[mbtiles]
+   comment = MBTiles archives
+   path = /opt/data/mbtiles
+   browseable = yes
+   guest ok = yes
+
 [backups]
    comment = Backups
    path = /opt/data/backups

--- a/kickstart/scripts/samba-deploy.sh
+++ b/kickstart/scripts/samba-deploy.sh
@@ -3,14 +3,32 @@
 deploy_samba_ubuntu() {
   apt-get install --no-install-recommends -y samba
 
+  # writable spot to share files with other POSM users
   mkdir -p /opt/data/public
   chown nobody:nogroup /opt/data/public
   chmod 777 /opt/data/public
 
+  # writable spot to put Field Papers snapshots
   mkdir -p /opt/data/fieldpapers
   chown nobody:nogroup /opt/data/fieldpapers
   chmod 777 /opt/data/fieldpapers
 
+  # writable spot to put input images for ODM
+  mkdir -p /opt/data/odm-input
+  chown nobody:nogroup /opt/data/odm-input
+  chmod 777 /opt/data/odm-input
+
+  # writable spot to put GeoTIFFs for tiling (and where ODM outputs are copied)
+  mkdir -p /opt/data/aerial-imagery
+  chown nobody:nogroup /opt/data/aerial-imagery
+  chmod 777 /opt/data/aerial-imagery
+
+  # read-only spot to copy MBTiles archives from
+  mkdir -p /opt/data/mbtiles
+  chown nobody:nogroup /opt/data/mbtiles
+  chmod 644 /opt/data/mbtiles
+
+  # read-only spot to copy backups from
   mkdir -p /opt/data/backups
   chmod 644 /opt/data/backups
 


### PR DESCRIPTION
Content within the `aerial-imagery` share (e.g. ODM outputs) should be hard-linked elsewhere to prevent it from being inadvertently deleted.

Fixes AmericanRedCross/posm#200
Fixes AmericanRedCross/posm#207
Refs AmericanRedCross/posm#213
