### PR TITLE
Install celery + RabbitMQ

### DIFF
--- a/kickstart/scripts/celery-deploy.sh
+++ b/kickstart/scripts/celery-deploy.sh
@@ -4,9 +4,10 @@ deploy_celery_ubuntu() {
   # explicitly with recommended packages so we get wheels and build tools
   apt install -y \
     python-pip
-    rabbitmq-server
+    redis-server
 
   pip install 'celery>3'
+  pip install 'redis'
   pip install -e 'git+https://github.com/celery/billiard.git#egg=billiard'
   pip install -e 'git+https://github.com/celery/kombu.git#egg=kombu'
 }

--- a/kickstart/scripts/celery-deploy.sh
+++ b/kickstart/scripts/celery-deploy.sh
@@ -7,6 +7,8 @@ deploy_celery_ubuntu() {
     rabbitmq-server
 
   pip install 'celery>3'
+  pip install -e 'git+https://github.com/celery/billiard.git#egg=billiard'
+  pip install -e 'git+https://github.com/celery/kombu.git#egg=kombu'
 }
 
 deploy celery

--- a/kickstart/scripts/celery-deploy.sh
+++ b/kickstart/scripts/celery-deploy.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+deploy_celery_ubuntu() {
+  # explicitly with recommended packages so we get wheels and build tools
+  apt install -y \
+    python-pip
+    rabbitmq-server
+
+  pip install 'celery>3'
+}
+
+deploy celery


### PR DESCRIPTION
Installs [Celery](http://www.celeryproject.org/) + RabbitMQ (so that the latter can be used as Celery's broker).

This installs celery@4.0.0rc4 at the time of this PR. The primary benefit of the 4.x series is that JSON is the default serialization format, allowing it to play better with non-Python clients.

As things evolve, it may/probably make sense to move these into Docker containers, but since the ODM workers need to manipulate Docker directly, it's easier to keep them outside of containers initially.
