### PR TITLE
Respond to *.openstreetmap.org

### DIFF
--- a/kickstart/etc/nginx-osm.conf
+++ b/kickstart/etc/nginx-osm.conf
@@ -1,6 +1,11 @@
 server {
+  server_name .openstreetmap.org .osm.org;
+  return 301 http://{{osm_fqdn}}$request_uri;
+}
+
+server {
   listen 80;
-  server_name {{osm_fqdn}};
+  server_name {{osm_fqdn}} www.openstreetmap.org;
 
   proxy_buffering off;
   proxy_http_version 1.1;


### PR DESCRIPTION
This enables OSM editors (e.g. Go Map!, JOSM) to transparently use the local OSM instance to pull (if not save) data.

Go Map! (for example, others may exhibit the same problem) uses HTTPS for login verification and to save edits, so those don't work at the moment. It (and they) hopefully verify SSL certs, so we may be out of luck. We could redirect to a hostname that we can provide an SSL cert for, but the initial response will likely be rejected...

/cc @dalekunce this may avoid the need to patch various editors (or configure proxy settings), but only if we can find a way around the SSL certificate problem, possibly by providing a custom CA certificate that users can install (though that's at its own peril).
