### PR TITLE
Don't install GIS tools from a PPA

### DIFF
--- a/kickstart/scripts/gis-deploy.sh
+++ b/kickstart/scripts/gis-deploy.sh
@@ -1,20 +1,8 @@
 #!/bin/bash
 
 deploy_gis_ubuntu() {
-  add-apt-repository -s -y ppa:ubuntugis/ppa
-  apt-get update
-  apt-get install --no-install-recommends -y \
-    libfreexl1 libfreexl-dev \
-    gdal-bin libgdal1h libgdal-dev python-gdal \
-    libgeos-3.4.2 libgeos-dev \
-    proj-bin libproj0 libproj-dev \
-    spatialite-bin libspatialite5 libspatialite-dev
-}
-
-deploy_gis_rhel() {
-  r=`lsb_release -sr | cut -d. -f 1`
-  rpm -Uvh "http://elgis.argeo.org/repos/$r/elgis-release-$r-${r}_0.noarch.rpm"
-  yum install gdal gdal-python geos geos-python libgeotiff libspatialite proj
+  apt-get install -y \
+    gdal-bin proj-bin spatialite-bin
 }
 
 deploy gis


### PR DESCRIPTION
Recent updates to UbuntuGIS (specifically gdal) are incompatible with "official" Postgres packaging, which includes PostGIS-2.3 (not yet available via UbuntuGIS).

Also drops references to RHEL because we weren't using it anywhere else.