### PR TITLE
Git submodule support for posm-local-home

### DIFF
--- a/kickstart/scripts/nginx-deploy.sh
+++ b/kickstart/scripts/nginx-deploy.sh
@@ -12,7 +12,7 @@ deploy_nginx_ubuntu() {
   mkdir -p /opt/posm-www
   chmod 755 /opt/posm-www
 
-  from_github "https://github.com/AmericanRedCross/posm-local-home" "$dst"
+  git clone --recursive --depth 1 https://github.com/AmericanRedCross/posm-local-home "$dst"
 }
 
 deploy nginx


### PR DESCRIPTION
Allows posm-admin2 to be pulled in automatically and sets the stage for additional documentation references.