### PR TITLE
Load A records from /etc/hosts

### DIFF
--- a/kickstart/etc/dnsmasq-posm.conf
+++ b/kickstart/etc/dnsmasq-posm.conf
@@ -37,7 +37,7 @@ no-dhcp-interface={{posm_wan_netif}}
 
 # If you don't want dnsmasq to read /etc/hosts, uncomment the
 # following line.
-no-hosts
+# no-hosts
 
 # Set this (and domain: see below) if you want to have a domain
 # automatically added to simple names in a hosts-file.
@@ -46,10 +46,6 @@ expand-hosts
 # Set fixed aliases (CNAME records)
 #cname=localposm.com,{{posm_fqdn}}
 cname={{osm_fqdn}},{{posm_fqdn}}
-
-# Set fixed addresses (A records)
-address=/{{posm_fqdn}}/{{posm_wlan_ip}}
-address=/{{posm_hostname}}.{{lan_domain}}/{{posm_wlan_ip}}
 
 # Set wildcard address (anything not in /etc/hosts, leases, or set above)
 # address=/#/{{posm_wlan_ip}}

--- a/kickstart/etc/hosts
+++ b/kickstart/etc/hosts
@@ -1,0 +1,5 @@
+127.0.0.1       localhost
+{{posm_wlan_ip}}       {{posm_fqdn}} {{posm_hostname}}.{{lan_domain}} {{posm_hostname}}
+::1             localhost ip6-localhost ip6-loopback
+ff02::1         ip6-allnodes
+ff02::2         ip6-allrouters

--- a/kickstart/scripts/wifi-deploy.sh
+++ b/kickstart/scripts/wifi-deploy.sh
@@ -23,6 +23,7 @@ deploy_wifi_ubuntu() {
 
 	  # allow lo to use remote DNS servers (don't modify /etc/resolve.conf)
 	  grep -qe "^DNSMASQ_EXCEPT" /etc/default/dnsmasq || echo DNSMASQ_EXCEPT=\"lo\" >> /etc/default/dnsmasq
+	  expand etc/hosts "/etc/hosts"
 
 	  # configure network interfaces
 	  expand etc/network/interfaces.d/usb0.cfg "/etc/network/interfaces.d/usb0.cfg"


### PR DESCRIPTION
`address=/<hostname>/<ip>` is actually a wildcard for `*.<hostname>`, so we need explicit entries in `/etc/hosts` instead.

Fixes AmericanRedCross/posm#253