### PR TITLE
Ensure that smbd starts after the network is up

### DIFF
--- a/kickstart/etc/init/smbd.override
+++ b/kickstart/etc/init/smbd.override
@@ -1,0 +1,1 @@
+start on (local-filesystems and started networking)

--- a/kickstart/scripts/samba-deploy.sh
+++ b/kickstart/scripts/samba-deploy.sh
@@ -33,6 +33,7 @@ deploy_samba_ubuntu() {
   chmod 644 /opt/data/backups
 
   expand etc/smb.conf /etc/samba/smb.conf
+  expand init/smbd.override /etc/init/smbd.override
 
   service samba restart
 }


### PR DESCRIPTION
This is necessary for it to correctly bind to the wireless interface.

Fixes AmericanRedCross/posm#231