### PR TITLE
Sync with ODM/Imagery API locations

### DIFF
--- a/kickstart/etc/smb.conf
+++ b/kickstart/etc/smb.conf
@@ -41,27 +41,15 @@
    directory mask = 0777
    writable = yes
 
-[odm-input]
-   comment = OpenDroneMap input images
-   path = /opt/data/odm-input
+[opendronemap]
+   comment = OpenDroneMap-produced artifacts
+   path = /opt/data/opendronemap
    browseable = yes
    guest ok = yes
-   create mask = 0777
-   directory mask = 0777
-   writable = yes
 
-[aerial-imagery]
-   comment = OpenDroneMap-produced artifacts + GeoTIFF inputs
-   path = /opt/data/aerial-imagery
-   browseable = yes
-   guest ok = yes
-   create mask = 0777
-   directory mask = 0777
-   writable = yes
-
-[mbtiles]
-   comment = MBTiles archives
-   path = /opt/data/mbtiles
+[imagery]
+   comment = Imagery and MBTiles
+   path = /opt/data/imagery
    browseable = yes
    guest ok = yes
 

--- a/kickstart/scripts/samba-deploy.sh
+++ b/kickstart/scripts/samba-deploy.sh
@@ -13,21 +13,6 @@ deploy_samba_ubuntu() {
   chown nobody:nogroup /opt/data/fieldpapers
   chmod 777 /opt/data/fieldpapers
 
-  # writable spot to put input images for ODM
-  mkdir -p /opt/data/odm-input
-  chown nobody:nogroup /opt/data/odm-input
-  chmod 777 /opt/data/odm-input
-
-  # writable spot to put GeoTIFFs for tiling (and where ODM outputs are copied)
-  mkdir -p /opt/data/aerial-imagery
-  chown nobody:nogroup /opt/data/aerial-imagery
-  chmod 777 /opt/data/aerial-imagery
-
-  # read-only spot to copy MBTiles archives from
-  mkdir -p /opt/data/mbtiles
-  chown nobody:nogroup /opt/data/mbtiles
-  chmod 644 /opt/data/mbtiles
-
   # read-only spot to copy backups from
   mkdir -p /opt/data/backups
   chmod 644 /opt/data/backups


### PR DESCRIPTION
Paths are created by their corresponding deploy scripts.