### PR TITLE
Show solid green once booted

### DIFF
--- a/kickstart/etc/init/blink1.conf
+++ b/kickstart/etc/init/blink1.conf
@@ -1,0 +1,8 @@
+description   "blink(1)"
+
+start on (local-filesystems and net-device-up and runlevel [2345])
+
+task
+script
+  /usr/local/bin/blink1-tool --rgb 00ff00
+end script

--- a/kickstart/scripts/blink1-deploy.sh
+++ b/kickstart/scripts/blink1-deploy.sh
@@ -6,6 +6,8 @@ deploy_blink1_ubuntu() {
   unzip -d /usr/local/bin $TMPFILE
   chmod +x /usr/local/bin/blink1-tool
   rm $TMPFILE
+
+  expand etc/init/blink1.conf /etc/init/blink1.conf
 }
 
 deploy blink1


### PR DESCRIPTION
When a [blink(1)](https://blink1.thingm.com/) is available, turn it green once the system has booted. This is convenient for knowing when a system has been initialized and no display is attached.

![img_2744](https://cloud.githubusercontent.com/assets/45/20125632/774aecc6-a5e3-11e6-8cb8-2eacf9628729.JPG)
