### PR TITLE
Write custom apt sources to sources.list.d

### DIFF
--- a/kickstart/scripts/docker-deploy.sh
+++ b/kickstart/scripts/docker-deploy.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 deploy_docker_ubuntu() {
-  apt install --no-install-recommends -y software-properties-common lsb-release apt-transport-https ca-certificates
+  apt install --no-install-recommends -y lsb-release apt-transport-https ca-certificates
   apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-  add-apt-repository "deb https://apt.dockerproject.org/repo ubuntu-$(lsb_release -c -s) main"
+  echo "deb https://apt.dockerproject.org/repo ubuntu-$(lsb_release -c -s) main" > /etc/apt/sources.list.d/dockerproject.list
   apt update
   apt install --no-install-recommends -y \
     docker-engine \

--- a/kickstart/scripts/nodejs-deploy.sh
+++ b/kickstart/scripts/nodejs-deploy.sh
@@ -4,7 +4,7 @@ node_ver="${node_ver:-4}"
 
 deploy_nodejs_ubuntu() {
   wget -q -O - https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-  add-apt-repository -s "deb https://deb.nodesource.com/node_${node_ver}.x $(lsb_release -c -s) main"
+  echo "deb https://deb.nodesource.com/node_${node_ver}.x $(lsb_release -c -s) main" > /etc/apt/sources.list.d/nodesource.list
   apt-get update
   apt-get install --no-install-recommends -y nodejs
 

--- a/kickstart/scripts/postgis-deploy.sh
+++ b/kickstart/scripts/postgis-deploy.sh
@@ -5,7 +5,7 @@ postgis_ver="${postgis_ver:-2.3}"
 
 deploy_postgis_ubuntu() {
   wget -q -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
-  add-apt-repository -s "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -c -s)-pgdg main"
+  echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -c -s)-pgdg main" > /etc/apt/sources.list.d/postgresql.list
   apt-get update
   apt-get install --no-install-recommends -y \
     postgis \


### PR DESCRIPTION
This allows sources.list to be managed by other tools (e.g. `cloud-init` and `casper` (which rewrites `sources.list` to refer to the USB stick during installation)) while retaining sources that we'd like registered.

Fixes AmericanRedCross/posm#216