### PR TITLE
Allow osm.posm.io to resolve from posm

### DIFF
--- a/kickstart/etc/dnsmasq-posm.conf
+++ b/kickstart/etc/dnsmasq-posm.conf
@@ -45,7 +45,6 @@ expand-hosts
 
 # Set fixed aliases (CNAME records)
 #cname=localposm.com,{{posm_fqdn}}
-cname={{osm_fqdn}},{{posm_fqdn}}
 
 # Set wildcard address (anything not in /etc/hosts, leases, or set above)
 # address=/#/{{posm_wlan_ip}}

--- a/kickstart/etc/hosts
+++ b/kickstart/etc/hosts
@@ -1,5 +1,5 @@
 127.0.0.1       localhost
-{{posm_wlan_ip}}       {{posm_fqdn}} {{posm_hostname}}.{{lan_domain}} {{posm_hostname}}
+{{posm_wlan_ip}}      {{posm_fqdn}} {{osm_fqdn}} {{posm_hostname}}.{{lan_domain}} {{posm_hostname}}
 ::1             localhost ip6-localhost ip6-loopback
 ff02::1         ip6-allnodes
 ff02::2         ip6-allrouters


### PR DESCRIPTION
posm doesn't use `dnsmasq` for name resolution (it uses external DNS servers if available to bypass its own captivity), so osm.posm.io (or whatever it's been configured to be) needs to be resolvable via `hosts`.