### PR TITLE
Must be root to run initctl

### DIFF
--- a/kickstart/etc/init.d/postgresql
+++ b/kickstart/etc/init.d/postgresql
@@ -38,11 +38,11 @@ case "$1" in
 	for v in $versions; do
 	    $1 $v || EXIT=$?
 	done
-	if [ "$1" = start -o "$1" = restart ]; then
-	    initctl emit -n started JOB=postgresql
-	fi
-	if [ "$1" = stop -o "$1" = restart ]; then
+	if [ $(whoami) = "root" ] && [ "$1" = stop -o "$1" = restart ]; then
 	    initctl emit -n stopped JOB=postgresql
+	fi
+	if [ $(whoami) = "root" ] && [ "$1" = start -o "$1" = restart ]; then
+	    initctl emit -n started JOB=postgresql
 	fi
 	exit ${EXIT:-0}
         ;;


### PR DESCRIPTION
Also reorders the emitted events when restarting so that "stopped" precedes "started".