### PR TITLE
Diff updates

### DIFF
--- a/kickstart/etc/apply-updates.sh
+++ b/kickstart/etc/apply-updates.sh
@@ -8,6 +8,7 @@ PATH=/usr/local/bin:/usr/sbin:/usr/bin:/bin
 if [ -f /opt/data/osm/state.txt ]; then
   db=$(jq -r .osm_carto_pg_dbname /etc/posm.json)
   timestamp=$(date -u +\%Y\%m\%d-\%H\%M)
+  # TODO use a named pipe
   expiry_file=/opt/data/osm/expiry/${timestamp}.txt
 
   osmosis \

--- a/kickstart/etc/apply-updates.sh
+++ b/kickstart/etc/apply-updates.sh
@@ -24,7 +24,7 @@ if [ -f /opt/data/osm/state.txt ]; then
       --extra-attributes \
       --database $db \
       --slim \
-      --expire-tiles 10-22 \
+      --expire-tiles 22 \
       --expire-output $expiry_file \
       - \
     2> /dev/null

--- a/kickstart/etc/apply-updates.sh
+++ b/kickstart/etc/apply-updates.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+PATH=/usr/local/bin:/usr/sbin:/usr/bin:/bin
+
+# --rri will automatically fetch the latest state.txt; it will initialized when osm2pgsql fully imports an extract
+if [ -f /opt/data/osm/state.txt ]; then
+  db=$(jq -r .osm_carto_pg_dbname /etc/posm.json)
+  timestamp=$(date -u +\%Y\%m\%d-\%H\%M)
+  expiry_file=/opt/data/osm/expiry/${timestamp}.txt
+
+  osmosis \
+    --read-replication-interval \
+      workingDirectory=/opt/data/osm \
+    --simplify-change \
+    --write-xml-change - \
+  2> /dev/null | \
+    osm2pgsql \
+      --append \
+      --hstore-all \
+      --hstore-add-index \
+      --extra-attributes \
+      --database $db \
+      --slim \
+      --expire-tiles 10-22 \
+      --expire-output $expiry_file \
+      - \
+    2> /dev/null
+
+  if [ -s $expiry_file ]; then
+    # restart if tiles would be expired
+    sudo service tessera restart > /dev/null
+  else
+    # remove the expiry file
+    rm -f $expiry_file
+  fi
+fi

--- a/kickstart/etc/gis.crontab
+++ b/kickstart/etc/gis.crontab
@@ -1,7 +1,3 @@
 PATH=/usr/local/bin:/usr/sbin:/usr/bin:/bin
 
-# --rri will automatically fetch the latest state.txt; it will initialized when osm2pgsql fully imports an extract
-# TODO extract this into a standalone command
-# TODO only restart tessera if tiles need to be expired
-# TODO delete expiration lists if they're 0-length
-* * * * * test -f /opt/data/osm/state.txt && sleep 30 && osmosis --read-replication-interval workingDirectory=/opt/data/osm --simplify-change --write-xml-change - 2> /dev/null | osm2pgsql -a --hstore-all --hstore-add-index --extra-attributes -d $(jq -r .osm_carto_pg_dbname /etc/posm.json) --slim --expire-tiles 10-22 -o /opt/data/osm/expiry/$(date -u +\%Y\%m\%d-\%H\%M).txt - 2> /dev/null && sudo service tessera restart > /dev/null
+* * * * * sleep 30 && apply-updates.sh

--- a/kickstart/etc/gis.crontab
+++ b/kickstart/etc/gis.crontab
@@ -3,4 +3,5 @@ PATH=/usr/local/bin:/usr/sbin:/usr/bin:/bin
 # --rri will automatically fetch the latest state.txt; it will initialized when osm2pgsql fully imports an extract
 # TODO extract this into a standalone command
 # TODO only restart tessera if tiles need to be expired
+# TODO delete expiration lists if they're 0-length
 * * * * * test -f /opt/data/osm/state.txt && sleep 30 && osmosis --read-replication-interval workingDirectory=/opt/data/osm --simplify-change --write-xml-change - 2> /dev/null | osm2pgsql -a --hstore-all --hstore-add-index --extra-attributes -d $(jq -r .osm_carto_pg_dbname /etc/posm.json) --slim --expire-tiles 10-22 -o /opt/data/osm/expiry/$(date -u +\%Y\%m\%d-\%H\%M).txt - 2> /dev/null && sudo service tessera restart > /dev/null

--- a/kickstart/etc/gis.crontab
+++ b/kickstart/etc/gis.crontab
@@ -3,4 +3,4 @@ PATH=/usr/local/bin:/usr/sbin:/usr/bin:/bin
 # --rri will automatically fetch the latest state.txt; it will initialized when osm2pgsql fully imports an extract
 # TODO extract this into a standalone command
 # TODO only restart tessera if tiles need to be expired
-* * * * * test -f /opt/data/osm/state.txt && sleep 30 && osmosis --read-replication-interval workingDirectory=/opt/data/osm --simplify-change --write-xml-change - 2> /dev/null | osm2pgsql -a --hstore-all --hstore-add-index --extra-attributes -d $(jq -r .osm_carto_pg_dbname /etc/posm.json) --slim --expire-tiles 10-22 -o /opt/data/osm/expiry/$(date -u +\%Y\%m\%d-\%H\%M).txt - 2> /dev/null && sudo service tessera restart
+* * * * * test -f /opt/data/osm/state.txt && sleep 30 && osmosis --read-replication-interval workingDirectory=/opt/data/osm --simplify-change --write-xml-change - 2> /dev/null | osm2pgsql -a --hstore-all --hstore-add-index --extra-attributes -d $(jq -r .osm_carto_pg_dbname /etc/posm.json) --slim --expire-tiles 10-22 -o /opt/data/osm/expiry/$(date -u +\%Y\%m\%d-\%H\%M).txt - 2> /dev/null && sudo service tessera restart > /dev/null

--- a/kickstart/etc/gis.crontab
+++ b/kickstart/etc/gis.crontab
@@ -1,0 +1,6 @@
+PATH=/usr/local/bin:/usr/sbin:/usr/bin:/bin
+
+# --rri will automatically fetch the latest state.txt; it will initialized when osm2pgsql fully imports an extract
+# TODO extract this into a standalone command
+# TODO only restart tessera if tiles need to be expired
+* * * * * test -f /opt/data/osm/state.txt && sleep 30 && osmosis --read-replication-interval workingDirectory=/opt/data/osm --simplify-change --write-xml-change - 2> /dev/null | osm2pgsql -a --hstore-all --hstore-add-index --extra-attributes -d $(jq -r .osm_carto_pg_dbname /etc/posm.json) --slim --expire-tiles 10-22 -o /opt/data/osm/expiry/$(date -u +\%Y\%m\%d-\%H\%M).txt - 2> /dev/null && sudo service tessera restart

--- a/kickstart/etc/osm.crontab
+++ b/kickstart/etc/osm.crontab
@@ -1,0 +1,1 @@
+* * * * * /usr/bin/osmosis --replicate-apidb authFile=/etc/osmosis/osm.properties allowIncorrectSchemaVersion=true --write-replication workingDirectory=/opt/data/osm/replication/minute 2> /dev/null

--- a/kickstart/etc/osmosis/osm.properties
+++ b/kickstart/etc/osmosis/osm.properties
@@ -1,0 +1,4 @@
+host=localhost
+database={{osm_pg_dbname}}
+user={{osm_pg_owner}}
+password={{osm_pg_pass}}

--- a/kickstart/etc/sudoers.d/posm-admin
+++ b/kickstart/etc/sudoers.d/posm-admin
@@ -1,3 +1,4 @@
+gis ALL=(root) NOPASSWD: /usr/sbin/service tessera restart
 osm ALL=(root) NOPASSWD: {{dst}}/posm-admin/scripts/root_change-osm-id-key.sh
 
 {{user}} ALL=(root) NOPASSWD: /usr/sbin/service tessera restart

--- a/kickstart/scripts/admin-deploy.sh
+++ b/kickstart/scripts/admin-deploy.sh
@@ -30,7 +30,6 @@ deploy_admin_ubuntu() {
   ln -s $deployments_dir $omk_deployments_dir
 
   deploy_posm_admin
-  setup_cron
 }
 
 deploy_posm_admin() {
@@ -57,19 +56,6 @@ deploy_posm_admin() {
   # start
   expand etc/posm-admin.upstart /etc/init/posm-admin.conf
   service posm-admin restart
-}
-
-# Occasionally we run cron jobs in the background. For example, we update periodically the render db.
-setup_cron() {
-  echo "Setting up admin crontab..."
-
-  # # We are having render-db-update.sh run every half hour.
-  # su - $user -c 'echo "0,30 * * * * /opt/admin/posm-admin/scripts/render-db-update.sh" > cronfile'
-  #
-  # #install new cron file
-  # su - $user -c 'crontab cronfile'
-  # su - $user -c 'rm cronfile'
-
 }
 
 deploy admin

--- a/kickstart/scripts/carto-deploy.sh
+++ b/kickstart/scripts/carto-deploy.sh
@@ -43,7 +43,7 @@ deploy_carto_posm() {
   service tessera restart
 
   # register a cron job that reads diffs and updates the rendering database
-  crontab -u $carto_user etc/gis.crontab
+  crontab -u $carto_user ${BOOTSTRAP_HOME}/etc/gis.crontab
 
   mkdir -p /opt/data/osm/expiry
   chown "$carto_user:$carto_user" /opt/data/osm

--- a/kickstart/scripts/carto-deploy.sh
+++ b/kickstart/scripts/carto-deploy.sh
@@ -41,6 +41,9 @@ deploy_carto_posm() {
 
   # restart
   service tessera restart
+
+  # register a cron job that reads diffs and updates the rendering database
+  crontab -u $carto_user etc/gis.crontab
 }
 
 deploy_carto_osm() {

--- a/kickstart/scripts/carto-deploy.sh
+++ b/kickstart/scripts/carto-deploy.sh
@@ -44,6 +44,14 @@ deploy_carto_posm() {
 
   # register a cron job that reads diffs and updates the rendering database
   crontab -u $carto_user etc/gis.crontab
+
+  mkdir -p /opt/data/osm/expiry
+  chown "$carto_user:$carto_user" /opt/data/osm
+  chown "$carto_user:$carto_user" /opt/data/osm/expiry
+
+  sudo -u $carto_user osmosis --read-replication-interval-init workingDirectory=/opt/data/osm
+  sudo -u $carto_user sed -Ei 's!^baseUrl\s?=.*$!baseUrl=file:///opt/data/osm/replication/minute!' /opt/data/osm/configuration.txt
+  sudo -u $carto_user sed -Ei 's!^maxInterval\s?=.*$!maxInterval=0!' /opt/data/osm/configuration.txt
 }
 
 deploy_carto_osm() {

--- a/kickstart/scripts/carto-deploy.sh
+++ b/kickstart/scripts/carto-deploy.sh
@@ -19,6 +19,10 @@ deploy_carto_ubuntu() {
   su - postgres -c "psql --dbname='$osm_carto_pg_temp_dbname' --command='CREATE EXTENSION postgis'"
   su - postgres -c "psql --dbname='$osm_carto_pg_temp_dbname' --command='CREATE EXTENSION hstore'"
   su - postgres -c "psql -d postgres -c 'ALTER USER $carto_user CREATEDB;'"
+
+  expand etc/apply-updates.sh /usr/local/bin/apply-updates.sh
+  chmod +x /usr/local/bin/apply-updates.sh
+
   local s
   for s in $carto_styles; do
     local fn="deploy_carto_$s"

--- a/kickstart/scripts/osm-deploy.sh
+++ b/kickstart/scripts/osm-deploy.sh
@@ -7,7 +7,7 @@ configure_osm_replication() {
   mkdir -p /opt/data/osm/replication/minute
   chown -R osm:osm /opt/data/osm/replication
 
-  mkdir /etc/osmosis
+  mkdir -p /etc/osmosis
   expand etc/osmosis/osm.properties /etc/osmosis/osm.properties
 
   crontab -u osm etc/osm.crontab

--- a/kickstart/scripts/osm-deploy.sh
+++ b/kickstart/scripts/osm-deploy.sh
@@ -4,18 +4,11 @@ dst=/opt/osm
 osmosis_ver="${osmosis_ver:-0.45}"
 
 configure_osm_replication() {
-  mkdir -p /opt/data/osm/expiry
-  chown -R gis:gis /opt/data/osm
-
   mkdir -p /opt/data/osm/replication/minute
   chown -R osm:osm /opt/data/osm/replication
 
   mkdir /etc/osmosis
   expand etc/osmosis/osm.properties /etc/osmosis/osm.properties
-
-  sudo -u gis osmosis --read-replication-interval-init workingDirectory=/opt/data/osm
-  sudo -u gis sed -Ei 's!^baseUrl\s?=.*$!baseUrl=file:///opt/data/osm/replication/minute!' /opt/data/osm/configuration.txt
-  sudo -u gis sed -Ei 's!^maxInterval\s?=.*$!maxInterval=0!' /opt/data/osm/configuration.txt
 
   crontab -u osm etc/osm.crontab
 }

--- a/kickstart/scripts/osm-deploy.sh
+++ b/kickstart/scripts/osm-deploy.sh
@@ -3,6 +3,23 @@
 dst=/opt/osm
 osmosis_ver="${osmosis_ver:-0.45}"
 
+configure_osm_replication() {
+  mkdir -p /opt/data/osm/expiry
+  chown -R gis:gis /opt/data/osm
+
+  mkdir -p /opt/data/osm/replication/minute
+  chown -R osm:osm /opt/data/osm/replication
+
+  mkdir /etc/osmosis
+  expand etc/osmosis/osm.properties /etc/osmosis/osm.properties
+
+  sudo -u gis osmosis --read-replication-interval-init workingDirectory=/opt/data/osm
+  sudo -u gis sed -Ei 's!^baseUrl\s?=.*$!baseUrl=file:///opt/data/osm/replication/minute!' /opt/data/osm/configuration.txt
+  sudo -u gis sed -Ei 's!^maxInterval\s?=.*$!maxInterval=0!' /opt/data/osm/configuration.txt
+
+  crontab -u osm etc/osm.crontab
+}
+
 # requires nodejs, postgis
 deploy_osm_rails_ubuntu() {
   apt-get install --no-install-recommends -y \
@@ -146,6 +163,8 @@ deploy_osm_ubuntu() {
 
   deploy_osm_cgimap_ubuntu
   deploy_osm_cgimap_common
+
+  configure_osm_replication
 }
 
 deploy_osmosis_prebuilt() {

--- a/kickstart/scripts/osm-deploy.sh
+++ b/kickstart/scripts/osm-deploy.sh
@@ -10,6 +10,14 @@ configure_osm_replication() {
   mkdir -p /etc/osmosis
   expand etc/osmosis/osm.properties /etc/osmosis/osm.properties
 
+  # initialize minutely replication
+  osmosis \
+    --replicate-apidb \
+      authFile=/etc/osmosis/osm.properties \
+      allowIncorrectSchemaVersion=true \
+    --write-replication \
+      workingDirectory=/opt/data/osm/replication/minute
+
   crontab -u osm ${BOOTSTRAP_HOME}/etc/osm.crontab
 }
 

--- a/kickstart/scripts/osm-deploy.sh
+++ b/kickstart/scripts/osm-deploy.sh
@@ -10,7 +10,7 @@ configure_osm_replication() {
   mkdir -p /etc/osmosis
   expand etc/osmosis/osm.properties /etc/osmosis/osm.properties
 
-  crontab -u osm etc/osm.crontab
+  crontab -u osm ${BOOTSTRAP_HOME}/etc/osm.crontab
 }
 
 # requires nodejs, postgis


### PR DESCRIPTION
Configures the local OSM instance to write minutely replication files to `/opt/data/osm/replication/minute` (as `osm`) and to apply them to the rendering database using `osm2pgsql` (as `gis`), both via cron.

Depends on https://github.com/AmericanRedCross/posm-admin/pull/15 for full implementation.