### PR TITLE
[WiP] SSL

### DIFF
--- a/kickstart/etc/nginx-posm.conf
+++ b/kickstart/etc/nginx-posm.conf
@@ -1,6 +1,9 @@
 server {
   listen 80;
+  listen 443 default_server ssl;
   server_name {{posm_hostname}} {{posm_hostname}}.local {{posm_hostname}}.{{lan_domain}} {{posm_fqdn}} {{posm_wlan_ip}};
+  ssl_certificate /etc/nginx/fullchain.pem;
+  ssl_certificate_key /etc/nginx/privkey.pem;
 
   proxy_buffering off;
   proxy_http_version 1.1;


### PR DESCRIPTION
Requires certificates to be present in `/etc/nginx/{fullchain,privkey}.pem`.

[`dehydrated -c`](https://github.com/lukas2511/dehydrated) was used to produce the necessary challenges (deployed to `export.posm.io:/var/www/dehydrated`).

`export.posm.io:/etc/nginx/sites-enabled/default` contains:

```
        location /.well-known/acme-challenge {
                alias /var/www/dehydrated;
        }
```

`config`:

```
CHALLENGETYPE="http-01"
CONTACT_EMAIL="seth@mojodna.net"
KEYSIZE="2048"
HOOK="./hook.sh"
WELLKNOWN=something
```

`domains.txt`:

```
posm.io
```

`hook.sh`:

```bash
#!/bin/sh

deploy_challenge() {
    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"

    # This hook is called once for every domain that needs to be
    # validated, including any alternative names you may have listed.
    #
    # Parameters:
    # - DOMAIN
    #   The domain name (CN or subject alternative name) being
    #   validated.
    # - TOKEN_FILENAME
    #   The name of the file containing the token to be served for HTTP
    #   validation. Should be served by your web server as
    #   /.well-known/acme-challenge/${TOKEN_FILENAME}.
    # - TOKEN_VALUE
    #   The token value that needs to be served for validation. For DNS
    #   validation, this is what you want to put in the _acme-challenge
    #   TXT record. For HTTP validation it is the value that is expected
    #   be found in the $TOKEN_FILENAME file.
    echo $DOMAIN
    echo "/.well-known/acme-challenge/${TOKEN_FILENAME}"
    echo $TOKEN_VALUE

    read -s -r -e < /dev/tty
}

clean_challenge() {
    local DOMAIN="${1}" TOKEN_FILENAME="${2}" TOKEN_VALUE="${3}"

    # This hook is called after attempting to validate each domain,
    # whether or not validation was successful. Here you can delete
    # files or DNS records that are no longer needed.
    #
    # The parameters are the same as for deploy_challenge.
}

deploy_cert() {
    local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}" TIMESTAMP="${6}"

    # This hook is called once for each certificate that has been
    # produced. Here you might, for instance, copy your new certificates
    # to service-specific locations and reload the service.
    #
    # Parameters:
    # - DOMAIN
    #   The primary domain name, i.e. the certificate common
    #   name (CN).
    # - KEYFILE
    #   The path of the file containing the private key.
    # - CERTFILE
    #   The path of the file containing the signed certificate.
    # - FULLCHAINFILE
    #   The path of the file containing the full certificate chain.
    # - CHAINFILE
    #   The path of the file containing the intermediate certificate(s).
    # - TIMESTAMP
    #   Timestamp when the specified certificate was created.
}

unchanged_cert() {
    local DOMAIN="${1}" KEYFILE="${2}" CERTFILE="${3}" FULLCHAINFILE="${4}" CHAINFILE="${5}"

    # This hook is called once for each certificate that is still
    # valid and therefore wasn't reissued.
    #
    # Parameters:
    # - DOMAIN
    #   The primary domain name, i.e. the certificate common
    #   name (CN).
    # - KEYFILE
    #   The path of the file containing the private key.
    # - CERTFILE
    #   The path of the file containing the signed certificate.
    # - FULLCHAINFILE
    #   The path of the file containing the full certificate chain.
    # - CHAINFILE
    #   The path of the file containing the intermediate certificate(s).

    echo "Unchanged."
}

HANDLER="$1"; shift
"$HANDLER" "$@"
```

Refs AmericanRedCross/posm#21