### PR TITLE
Upgrade OSM + iD (to 2.2.0) + load locally-available imagery

### DIFF
--- a/kickstart/etc/nginx-osm.conf
+++ b/kickstart/etc/nginx-osm.conf
@@ -61,6 +61,10 @@ server {
   location /assets/ {
     alias /opt/osm/osm-web/public/assets/;
   }
+
+  location /iD/ {
+    alias /opt/osm/osm-web/vendor/assets/iD/iD/;
+  }
 }
 
 # vim: set sts=2 sw=2 et si nu:

--- a/kickstart/etc/nginx-posm.conf
+++ b/kickstart/etc/nginx-posm.conf
@@ -21,6 +21,13 @@ server {
   location / {
     try_files $uri $uri/ =404;
     index index.html;
+
+    if ($request_method = 'GET') {
+       add_header 'Access-Control-Allow-Origin' '*';
+       add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+       add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+       add_header 'Access-Control-Expose-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+    }
   }
 
   location ~ /\. {

--- a/kickstart/etc/root.crontab
+++ b/kickstart/etc/root.crontab
@@ -1,0 +1,1 @@
+* * * * * /usr/bin/posm-imagery-updater > /opt/posm-www/posm_imagery.json

--- a/kickstart/scripts/osm-deploy.sh
+++ b/kickstart/scripts/osm-deploy.sh
@@ -59,7 +59,7 @@ deploy_osm_rails() {
   npm install -g svgo
 
   # install OSM WEB
-  from_github "https://github.com/AmericanRedCross/openstreetmap-website" "$dst/osm-web" "posm"
+  from_github "https://github.com/AmericanRedCross/openstreetmap-website" "$dst/osm-web" "posm-v0.7.0"
   chown -R osm:osm "$dst/osm-web"
 
   # upstart-friendly serving + logging
@@ -92,7 +92,7 @@ deploy_osm_rails() {
 
   su - osm -c "cd '$dst/osm-web' && bundle exec rake db:migrate"
 
-  su - osm -c "sed -i -e \"s/posm.io/${posm_fqdn}/\" $dst/osm-web/vendor/assets/iD/imagery.js"
+  su - osm -c "sed -i -e \"s/posm.io/${posm_fqdn}/\" $dst/osm-web/app/assets/javascripts/id.js"
   su - osm -c "sed -i -e \"s/posm.io/${posm_fqdn}/\" $dst/osm-web/app/assets/javascripts/leaflet.map.js"
 
   # assets

--- a/kickstart/scripts/tessera-deploy.sh
+++ b/kickstart/scripts/tessera-deploy.sh
@@ -7,7 +7,7 @@ deploy_tessera_ubuntu() {
 
   npm install -g mapnik@~3.5.14 mbtiles tilelive tilelive-mapnik tilelive-carto tilelive-tmstyle \
     tilelive-tmsource tilelive-file tilelive-http tilelive-mapbox tilejson tilelive-vector \
-    tilelive-blend tessera
+    tilelive-blend tessera posm/posm-imagery-updater
 
   # configure
   mkdir -p /etc/tessera.conf.d
@@ -15,6 +15,8 @@ deploy_tessera_ubuntu() {
   expand etc/tessera.upstart /etc/init/tessera.conf
 
   service tessera restart
+
+  crontab -u osm ${BOOTSTRAP_HOME}/etc/root.crontab
 }
 
 deploy tessera


### PR DESCRIPTION
It'd be nice to include openstreetmap/iD#4032 in this, as it addresses cases where people try to use the geocoder. Otherwise, we're now on upstream iD with no modifications; all that's left is a set of patches to openstreetmap-website.