### PR TITLE
set max nodeodm tasks to 1

### DIFF
--- a/kickstart/etc/settings
+++ b/kickstart/etc/settings
@@ -71,6 +71,9 @@ webodm_webapp_digest="sha256:417beb021da272635c0004f8107ef42c214c624ad9d3411bebf
 webodm_nodeodm_digest="sha256:ae2345df2e4f7756e208f7b0717c6b9b95fb3a67612fa84295cdc6b4ba985eaf"
 webodm_clusterodm_digest="sha256:62e5a2073ee84adf6ee86e8744f2c34d5c70ae77ce6c7ce21e359703cb2d3fdb"
 
+# nodeodm
+nodeodm_parallel_queue=1
+
 # databases
 fp_pg_owner="fieldpapers"
 fp_pg_pass="fieldpapers"

--- a/kickstart/etc/systemd/system/nodeodm.service.hbs
+++ b/kickstart/etc/systemd/system/nodeodm.service.hbs
@@ -14,6 +14,7 @@ ExecStart=/bin/bash -c "docker run \
     --tmpfs /tmp \
     --network host \
     opendronemap/nodeodm@{{webodm_nodeodm_digest}} \
+    --parallel_queue_processing {{nodeodm_parallel_queue}} \
     --port {{nodeodm_port}}"
 
 [Install]


### PR DESCRIPTION
Errors during testing may have resulted from a processing node attempted to process two 400 images. 32GB of RAM is probably not sufficient (our recommended hardware). NodeODM [defaults to 2](https://github.com/OpenDroneMap/NodeODM/blob/master/config.js#L34) for the number of simultaneous processing tasks.
```
-q, --parallel_queue_processing <number> Number of simultaneous processing tasks (default: 2)
```
Piero recommends limiting the max tasks over reducing the split #s so that a node should be able to handle 2 tasks at a time. This pull request sets the max tasks to 1.