### PR TITLE
Add odk-central to POSM

### DIFF
--- a/kickstart/etc/hosts
+++ b/kickstart/etc/hosts
@@ -1,5 +1,5 @@
 127.0.0.1       localhost
-{{posm_wlan_ip}}      {{posm_fqdn}} {{osm_fqdn}} {{webodm_fqdn}} {{posm_hostname}}.{{lan_domain}} {{posm_hostname}}
+{{posm_wlan_ip}}      {{posm_fqdn}} {{osm_fqdn}} {{webodm_fqdn}} {{posm_hostname}}.{{lan_domain}} {{posm_hostname}} {{odk_central_fqdn}}
 ::1		localhost6.localdomain6	localhost6
 
 # The following lines are desirable for IPv6 capable hosts

--- a/kickstart/etc/nginx-odk-central.conf
+++ b/kickstart/etc/nginx-odk-central.conf
@@ -1,0 +1,52 @@
+server {
+    listen 80;
+    server_name {{odk_central_fqdn}};
+
+    add_header X-Content-Type-Options nosniff;
+    client_max_body_size 100M;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1280;
+    gzip_http_version 1.1;
+    gzip_types text/plain text/css application/json application/x-javascript text/xml text/csv;
+
+    # proxy_buffering off;
+    # proxy_http_version 1.1;
+    # proxy_set_header Upgrade $http_upgrade;
+    # proxy_set_header Connection 'upgrade';
+    # proxy_set_header Host $host;
+    # proxy_cache_bypass $http_upgrade;
+
+    {{#auth}}
+    auth_basic "POSM";
+    auth_basic_user_file htpasswd;
+    {{/auth}}
+
+    location ~ /\. {
+        # do not serve dot files ever
+        return 404;
+    }
+
+    location ~ ^/v\d {
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_pass http://127.0.0.1:{{odk_central_web_port}};
+        proxy_redirect off;
+
+        # set up request-body gzip decompression:
+        set $max_chunk_size 16384;    # ~16KB
+        set $max_body_size 134217728; # ~128MB
+        # rewrite_by_lua_file inflate_body.lua;
+
+        # buffer requests, but not responses, so streaming out works.
+        proxy_request_buffering on;
+        proxy_buffering off;
+        proxy_read_timeout 2m;
+    }
+
+    location / {
+        root /opt/odk-central/client-build;
+    }
+}
+
+# vim: set sts=2 sw=2 et si nu:

--- a/kickstart/etc/odk-central-docker-compose.yml
+++ b/kickstart/etc/odk-central-docker-compose.yml
@@ -3,7 +3,7 @@ services:
   postgres:
     image: "postgres:9.6"
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - ./central-data/db-data:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: odk
       POSTGRES_PASSWORD: odk
@@ -15,6 +15,8 @@ services:
       - ./files/dkim/rsa.private:/etc/exim4/domain.key:ro
     environment:
       - MAILNAME={{odk_central_fqdn}}
+  pyxform:
+    image: 'yanokwa/pyxform-http:v0.3.0'
   service:
     build:
       context: .
@@ -22,10 +24,12 @@ services:
     depends_on:
       - postgres
       - mail
+      - pyxform
     volumes:
-      - /data/transfer:/data/transfer
+      - ./central-data/transfer:/data/transfer
     environment:
       - DOMAIN={{odk_central_fqdn}}
+      - DOMAIN_PROTOCOL=http
     command: [ "./wait-for-it.sh", "postgres:5432", "--", "./start-odk.sh" ]
     ports:
       - "8383:8383"
@@ -33,8 +37,3 @@ services:
     build:
       context: .
       dockerfile: nginx.dockerfile
-  pyxform:
-    image: 'yanokwa/pyxform-http:v0.3.0'
-volumes:
-  transfer:
-  db-data:

--- a/kickstart/etc/odk-central-docker-compose.yml
+++ b/kickstart/etc/odk-central-docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3"
+services:
+  postgres:
+    image: "postgres:9.6"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: odk
+      POSTGRES_PASSWORD: odk
+      POSTGRES_DATABASE: odk
+  mail:
+    image: "itsissa/namshi-smtp:4.89-2.deb9u5"
+    volumes:
+      - ./files/dkim/config:/etc/exim4/_docker_additional_macros:ro
+      - ./files/dkim/rsa.private:/etc/exim4/domain.key:ro
+    environment:
+      - MAILNAME={{odk_central_fqdn}}
+  service:
+    build:
+      context: .
+      dockerfile: service.dockerfile
+    depends_on:
+      - postgres
+      - mail
+    volumes:
+      - /data/transfer:/data/transfer
+    environment:
+      - DOMAIN={{odk_central_fqdn}}
+    command: [ "./wait-for-it.sh", "postgres:5432", "--", "./start-odk.sh" ]
+    ports:
+      - "8383:8383"
+  nginx:
+    build:
+      context: .
+      dockerfile: nginx.dockerfile
+  pyxform:
+    image: 'yanokwa/pyxform-http:v0.3.0'
+volumes:
+  transfer:
+  db-data:

--- a/kickstart/etc/posm.json
+++ b/kickstart/etc/posm.json
@@ -18,9 +18,11 @@
   "posm_domain": "{{posm_domain}}",
   "posm_fqdn": "{{posm_fqdn}}",
   "osm_fqdn": "{{osm_fqdn}}",
+  "odk_central_fqdn": "{{odk_central_fqdn}}",
   "webodm_fqdn": "{{webodm_fqdn}}",
   "posm_base_url": "{{posm_base_url}}",
   "osm_base_url": "{{osm_base_url}}",
+  "odk_central_base_url": "{{odk_central_base_url}}",
   "lan_domain": "{{lan_domain}}",
   "fp_api_base_url": "{{fp_api_base_url}}",
   "fp_tile_base_url": "{{fp_tile_base_url}}",
@@ -30,6 +32,7 @@
   "tessera_port": "{{tessera_port}}",
   "omk_server_port": "{{omk_server_port}}",
   "osm_web_port": "{{osm_web_port}}",
+  "odk_central_web_port": "{{odk_central_web_port}}",
   "cgimap_port": "{{cgimap_port}}",
   "nodeodm_port": "{{nodeodm_port}}",
   "webodm_port": "{{webodm_port}}",
@@ -51,5 +54,7 @@
   "webodm_user": "{{webodm_user}}",
   "webodm_password": "{{webodm_password}}",
   "webodm_webapp_digest": "{{webodm_webapp_digest}}",
-  "webodm_nodeodm_digest": "{{webodm_nodeodm_digest}}"
+  "webodm_nodeodm_digest": "{{webodm_nodeodm_digest}}",
+  "odk_central_user": "{{odk_central_user}}",
+  "odk_central_password": "{{odk_central_password}}"
 }

--- a/kickstart/etc/settings
+++ b/kickstart/etc/settings
@@ -28,11 +28,13 @@ posm_domain="io"
 lan_domain="lan"
 posm_fqdn="posm.io"
 osm_fqdn="osm.${posm_fqdn}"
+odk_central_fqdn="odk-central.${posm_fqdn}"
 webodm_fqdn="webodm.${posm_fqdn}"
 
 # urls
 posm_base_url="http://${posm_fqdn}"
 osm_base_url="http://${osm_fqdn}"
+odk_central_base_url="http://${odk_central_fqdn}"
 fp_api_base_url="${posm_base_url}/fp"
 fp_tile_base_url="${posm_base_url}/fp-tiler"
 
@@ -44,6 +46,7 @@ tessera_port=8082
 omk_server_port=3210
 posm_admin_port=3211
 osm_web_port=9000
+odk_central_web_port=8383
 cgimap_port=54321
 clusterodm_port=3000
 nodeodm_port=3001
@@ -70,6 +73,10 @@ webodm_password="awesomeposm"
 webodm_webapp_digest="sha256:df6cd688538b5d05f84e5044f5daf05198a47a600a1f864a731969a5abdf4a5a"
 webodm_nodeodm_digest="sha256:b46bda1e357695ac7b8eeb6da2de6a3285c7e0ce67e9def0543deebf24fd5c93"
 webodm_clusterodm_digest="sha256:76499f059af9ada4bf5e36a7a56ca3a00db3608dab3f39510c40ceefe9d94c78"
+
+# odk-central
+odk_central_user="posm@posm.io"
+odk_central_password="awesomeposm"
 
 # nodeodm
 nodeodm_parallel_queue=1

--- a/kickstart/etc/systemd/system/odk-central.service.hbs
+++ b/kickstart/etc/systemd/system/odk-central.service.hbs
@@ -1,0 +1,14 @@
+[Unit]
+Description=ODK Central
+After=docker.service
+Requires=docker.service
+
+[Service]
+# Restart=always
+Restart=on-failure
+WorkingDirectory=/opt/odk-central/odk-central-repo
+ExecStart=/usr/local/bin/docker-compose up service
+ExecStop=/usr/local/bin/docker-compose stop
+
+[Install]
+WantedBy=multi-user.target

--- a/kickstart/scripts/odk-central-deploy.sh
+++ b/kickstart/scripts/odk-central-deploy.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -e
+
+dst=/opt/odk-central
+repo_path=$dst/odk-central-repo
+build_path=$dst/client-build
+odk_central_release_tag='posm'
+
+# Ubuntu-specific deployment
+deploy_odk_central_ubuntu() {
+    mkdir -p "$dst"
+    chmod 755 "$dst"
+
+    # Clone ODK central
+    git clone https://github.com/posm/central --branch $odk_central_release_tag $repo_path
+    cd $repo_path
+    git submodule update -i  # git pull ODK client and server
+
+    # Build Docker Images (Using custom docker-compose.yml)
+    expand etc/odk-central-docker-compose.yml $repo_path/docker-compose.yml
+    docker-compose build
+
+    # Copy Client Build
+    docker-compose run --rm \
+        --volume="$build_path:/host-client-build/" \
+        --entrypoint="cp -vr /usr/share/nginx/html/. /host-client-build/" nginx
+    chown www-data:www-data "$build_path" -R
+
+    # Create containers for odk-central and initial user with admin access
+    docker-compose up service -d
+    docker-compose exec service bash -c "
+        npm install -g wait-port && wait-port 8383 && odk-cmd --email $odk_central_user user-create --password $odk_central_password"
+    docker-compose exec service odk-cmd --email $odk_central_user user-promote
+    docker-compose stop
+
+    # Enable and run odk-central.service
+    expand etc/systemd/system/odk-central.service.hbs /etc/systemd/system/odk-central.service
+    systemctl enable --now odk-central.service
+
+    # Copy and enable nginx configuration
+    expand etc/nginx-odk-central.conf /etc/nginx/sites-available/odk-central
+    ln -s -f ../sites-available/odk-central /etc/nginx/sites-enabled/
+    service nginx restart
+}
+
+deploy odk_central

--- a/live/Makefile
+++ b/live/Makefile
@@ -149,7 +149,12 @@ telegraf: influxdb
 	lxc snapshot $$(cat container) $@
 	touch $@
 
-posm-core: gis nginx osm fieldpapers omk tl carto tessera admin samba blink1 influxdb telegraf
+odk-central: base
+	lxc exec $$(cat container) -- /root/posm-build/kickstart/scripts/bootstrap.sh $@
+	lxc snapshot $$(cat container) $@
+	touch $@
+
+posm-core: gis nginx osm fieldpapers omk tl carto tessera admin samba blink1 influxdb telegraf odk-central
 
 posm: posm-core wifi
 	lxc exec $$(cat container) -- systemctl stop docker


### PR DESCRIPTION
### Changes
- Add [ODK Central](https://github.com/opendatakit/central) to posm at `odk-central.posm.io`.
- Repository used: (Using branch `posm` for all repository)
   - https://github.com/posm/central/tree/posm
   - https://github.com/posm/central-frontend/tree/posm
   - https://github.com/posm/central-backend/tree/posm
- Diff available here https://github.com/opendatakit/central/compare/master...posm:posm
- Creating initial user with credential `posm@posm.io:awesomeposm`.

### Feedback Fixes
- central diff https://github.com/posm/central/commit/e25606b52510a9b843d66c43d1737c19cef45279
- Add pyxform as a dependent of the odk service (backend). https://github.com/posm/posm/issues/364
- Using local directory for docker volume to preserve data from posm-build. https://github.com/posm/posm/issues/363